### PR TITLE
EJBCLIENT-39 Take into account the invocation timeout setting even for session creation

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -22,6 +22,7 @@
 
 package org.jboss.ejb.client.remoting;
 
+import org.jboss.ejb.client.EJBClientConfiguration;
 import org.jboss.ejb.client.EJBClientInvocationContext;
 import org.jboss.ejb.client.EJBReceiver;
 import org.jboss.ejb.client.EJBReceiverContext;
@@ -232,8 +233,14 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
             }
         }
         final EJBReceiverInvocationContext.ResultProducer resultProducer;
+        final EJBClientConfiguration ejbClientConfiguration = receiverContext.getClientContext().getEJBClientConfiguration();
+        final long invocationTimeout = ejbClientConfiguration == null ? 0 : ejbClientConfiguration.getInvocationTimeout();
         try {
-            resultProducer = futureResultProducer.get();
+            if (invocationTimeout <= 0 ) {
+                resultProducer = futureResultProducer.get();
+            } else {
+                resultProducer = futureResultProducer.get(invocationTimeout, TimeUnit.MILLISECONDS);
+            }
         } catch (Exception e) {
             throw new RuntimeException(e);
         }


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/EJBCLIENT-39 where the invocation timeout configuration wasn't being used for session creation requests (for SFSBs). 

Please review and merge this commit to _both_ 1.0 and master branches upstream.
