### PR TITLE
Fix EJBCLIENT-42

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -495,6 +495,12 @@ public final class EJBClientInvocationContext extends Attachable {
                 if (state != State.WAITING) {
                     return false;
                 }
+                // if we aren't allowed to interrupt a running task, then skip the cancellation
+                if (!mayInterruptIfRunning) {
+                    return false;
+                }
+                // at this point the task is running and we are allowed to interrupt it. So issue
+                // a cancel request and change the current state
                 state = State.CANCEL_REQ;
             }
             return getReceiver().cancelInvocation(EJBClientInvocationContext.this, receiverInvocationContext);

--- a/src/main/java/org/jboss/ejb/client/Logs.java
+++ b/src/main/java/org/jboss/ejb/client/Logs.java
@@ -251,6 +251,9 @@ public interface Logs extends BasicLogger {
     @Message(id = 58, value = "Could not create the deployment node selector")
     RuntimeException couldNotCreateDeploymentNodeSelector(@Cause Exception e);
 
+    @LogMessage(level = WARN)
+    @Message(id = 59, value = "Could not send a message over remoting channel, to cancel invocation for invocation id %s")
+    void failedToSendInvocationCancellationMessage(short invocationId, @Cause Exception e);
 
     // Proxy API errors
 

--- a/src/main/java/org/jboss/ejb/client/remoting/InvocationCancellationMessageWriter.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/InvocationCancellationMessageWriter.java
@@ -26,7 +26,9 @@ import java.io.DataOutput;
 import java.io.IOException;
 
 /**
- * User: jpai
+ * Writes out a message to indicate that a prior invocation has to be cancelled
+ *
+ * @author Jaikiran Pai
  */
 class InvocationCancellationMessageWriter extends AbstractMessageWriter {
 
@@ -36,7 +38,7 @@ class InvocationCancellationMessageWriter extends AbstractMessageWriter {
      * Writes out a invocation cancel request message to the passed <code>output</code>
      *
      * @param output       The {@link java.io.DataOutput} to which the message will be written
-     * @param invocationId The invocation id
+     * @param invocationId The id corresponding to the invocation which is being cancelled
      * @throws java.io.IOException If there's a problem writing out to the {@link java.io.DataOutput}
      */
     void writeMessage(final DataOutput output, final short invocationId) throws IOException {


### PR DESCRIPTION
Please merge the commit in the pull request, to both 1.0 and master branches, upstream.

The commit here fixes the issue reported in https://issues.jboss.org/browse/EJBCLIENT-42. The cancelInvocation() method is now implemented in the RemotingConnectionEJBReceiver so that the server now knows about the cancellation request.
