### PR TITLE
[1.0] Implement EJBCLIENT-61 feature request

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
@@ -70,9 +70,27 @@ public class ConfigBasedEJBClientContextSelector implements IdentityEJBClientCon
      * @param ejbClientConfiguration The EJB client configuration to use
      */
     public ConfigBasedEJBClientContextSelector(final EJBClientConfiguration ejbClientConfiguration) {
+        this(ejbClientConfiguration, null);
+    }
+
+    /**
+     * Creates a {@link ConfigBasedEJBClientContextSelector} using the passed <code>ejbClientConfiguration</code>.
+     * <p/>
+     * This constructor creates a {@link EJBClientContext} and uses the passed <code>ejbClientConfiguration</code> to create and
+     * associated EJB receivers to that context. If the passed <code>ejbClientConfiguration</code> is null, then this selector will create a {@link EJBClientContext}
+     * without any associated EJB receivers.
+     *
+     * @param ejbClientConfiguration The EJB client configuration to use
+     * @param classLoader The classloader that will be used to {@link EJBClientContext#create(org.jboss.ejb.client.EJBClientConfiguration, ClassLoader) create the EJBClientContext}
+     */
+    public ConfigBasedEJBClientContextSelector(final EJBClientConfiguration ejbClientConfiguration, final ClassLoader classLoader) {
         this.ejbClientConfiguration = ejbClientConfiguration;
         // create a empty context
-        this.ejbClientContext = EJBClientContext.create(this.ejbClientConfiguration);
+        if (classLoader == null) {
+            this.ejbClientContext = EJBClientContext.create(this.ejbClientConfiguration);
+        } else {
+            this.ejbClientContext = EJBClientContext.create(this.ejbClientConfiguration, classLoader);
+        }
         // register a EJB client context listener which we will use to close endpoints/connections that we created,
         // when the EJB client context closes
         this.ejbClientContext.registerEJBClientContextListener(this.remotingCleanupHandler);

--- a/src/test/java/org/jboss/ejb/client/ClasspathConfigBasedSelectorTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/ClasspathConfigBasedSelectorTestCase.java
@@ -26,6 +26,7 @@ import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.ejb.client.remoting.RemotingConnectionEJBReceiver;
 import org.jboss.ejb.client.test.common.EchoBean;
 import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.ResourceSwitchingClassLoader;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -94,7 +95,7 @@ public class ClasspathConfigBasedSelectorTestCase {
 
         final EJBClientContext ejbClientContext = configBasedEJBClientContextSelector.getCurrent();
         logger.info("Found EJB client context " + ejbClientContext);
-        Assert.assertNotNull("No client context found " + ejbClientContext);
+        Assert.assertNotNull("No client context found", ejbClientContext);
         final Collection<EJBReceiver> ejbReceivers = ejbClientContext.getEJBReceivers("dummy-app", "dummy-module", "");
         Assert.assertNotNull("No EJB receivers found ", ejbReceivers);
         Assert.assertEquals("Unexpected number of EJB receivers", 1, ejbReceivers.size());

--- a/src/test/java/org/jboss/ejb/client/EJBClientPropertiesDisableClassLoaderScanTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/EJBClientPropertiesDisableClassLoaderScanTestCase.java
@@ -25,6 +25,7 @@ package org.jboss.ejb.client;
 import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.ejb.client.test.common.EchoBean;
 import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.ResourceSwitchingClassLoader;
 import org.jboss.logging.Logger;
 import org.junit.AfterClass;
 import org.junit.Assert;

--- a/src/test/java/org/jboss/ejb/client/test/common/ResourceSwitchingClassLoader.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/ResourceSwitchingClassLoader.java
@@ -20,24 +20,26 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-package org.jboss.ejb.client;
+package org.jboss.ejb.client.test.common;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.util.Enumeration;
 
 import org.jboss.logging.Logger;
 
 /**
  * @author Jaikiran Pai
  */
-class ResourceSwitchingClassLoader extends ClassLoader {
+public class ResourceSwitchingClassLoader extends ClassLoader {
 
     private static final Logger logger = Logger.getLogger(ResourceSwitchingClassLoader.class);
 
     private final String resourceName;
     private final String altResourceName;
 
-    ResourceSwitchingClassLoader(final String resourceName, final String altResourceName) {
+    public ResourceSwitchingClassLoader(final String resourceName, final String altResourceName) {
         if (resourceName == null || resourceName.trim().isEmpty()) {
             throw new IllegalArgumentException("Resource name cannot be null or empty");
         }
@@ -66,5 +68,15 @@ class ResourceSwitchingClassLoader extends ClassLoader {
             return is;
         }
         return super.getResourceAsStream(name);
+    }
+
+    @Override
+    public Enumeration<URL> getResources(String name) throws IOException {
+        if (this.resourceName.equals(name)) {
+            final Enumeration<URL> resources = super.getResources(this.altResourceName);
+            logger.info("getResources was called for " + name + " ,returning " + resources + " for " + this.altResourceName + " resource instead");
+            return resources;
+        }
+        return super.getResources(name);
     }
 }

--- a/src/test/java/org/jboss/ejb/client/test/interceptor/ClasspathEJBClientInterceptorsTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/interceptor/ClasspathEJBClientInterceptorsTestCase.java
@@ -1,0 +1,132 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client.test.interceptor;
+
+import org.jboss.ejb.client.ClasspathConfigBasedSelectorTestCase;
+import org.jboss.ejb.client.EJBClient;
+import org.jboss.ejb.client.EJBClientConfiguration;
+import org.jboss.ejb.client.EJBClientContext;
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.PropertiesBasedEJBClientConfiguration;
+import org.jboss.ejb.client.StatelessEJBLocator;
+import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
+import org.jboss.ejb.client.test.common.DummyServer;
+import org.jboss.ejb.client.test.common.EchoBean;
+import org.jboss.ejb.client.test.common.EchoRemote;
+import org.jboss.ejb.client.test.common.ResourceSwitchingClassLoader;
+import org.jboss.logging.Logger;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Properties;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class ClasspathEJBClientInterceptorsTestCase {
+    private static final Logger logger = Logger.getLogger(ClasspathConfigBasedSelectorTestCase.class);
+
+    private static DummyServer server;
+    private static final String SERVER_ENDPOINT_NAME = "classpath-ejb-client-interceptors-test-case-endpoint";
+
+    // setup a resource switching classloader
+    final ClassLoader resourceSwitchingCL = new ResourceSwitchingClassLoader("META-INF/services/" + EJBClientInterceptor.class.getName(), "ejb-client-interceptors." + EJBClientInterceptor.class.getName());
+
+    @BeforeClass
+    public static void beforeClass() throws Exception {
+        server = new DummyServer("localhost", 7999, SERVER_ENDPOINT_NAME);
+        server.start();
+        server.register("dummy-app", "dummy-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+    }
+
+
+    @AfterClass
+    public static void afterClass() throws Exception {
+        if (server != null) {
+            server.stop();
+        }
+    }
+
+    /**
+     * Tests that client interceptors added explicitly to the EJBClientContext and also found by the service loader
+     * mechanism in the client classpath are invoked in the right order during an invocation on the EJB
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void testEJBClientInterceptorsOnClasspath() throws Exception {
+        final Properties properties = this.getEJBClientConfigurationProperties();
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(properties);
+        final ConfigBasedEJBClientContextSelector configBasedEJBClientContextSelector = new ConfigBasedEJBClientContextSelector(ejbClientConfiguration, this.resourceSwitchingCL);
+        final EJBClientContext previousClientContext = EJBClientContext.getCurrent();
+        try {
+            // switch to our test EJB client context
+            final EJBClientContext ejbClientContext = configBasedEJBClientContextSelector.getCurrent();
+            // add an explicit interceptor
+            ejbClientContext.registerInterceptor(99999, new InterceptorThree());
+            EJBClientContext.setConstantContext(ejbClientContext);
+            final StatelessEJBLocator<EchoRemote> statelessEJBLocator = new StatelessEJBLocator<EchoRemote>(EchoRemote.class, "dummy-app", "dummy-module", EchoBean.class.getSimpleName(), "");
+            final EchoRemote proxy = EJBClient.createProxy(statelessEJBLocator);
+            final String message = "foo";
+            // The explicitly added client interceptor should be invoked first and then all the interceptors in the client
+            // classpath are supposed to be invoked in the order they are found in classpath
+            final String expectedEcho = InterceptorThree.class.getName() + " " + InterceptorTwo.class.getName() + " " + InterceptorOne.class.getName() + " " + message;
+            final String echo = proxy.echo(message);
+            Assert.assertEquals("Unexpected echo message which was expected to be intercepted", expectedEcho, echo);
+        } finally {
+            if (previousClientContext != null) {
+                EJBClientContext.setConstantContext(previousClientContext);
+            }
+        }
+        final EJBClientContext ejbClientContext = configBasedEJBClientContextSelector.getCurrent();
+        Assert.assertNotNull("No client context found", ejbClientContext);
+
+    }
+
+    /**
+     * Returns the properties that can be passed on to the constructor of the {@link javax.naming.InitialContext}
+     * to create scoped EJB client contexts
+     *
+     * @return
+     * @throws Exception
+     */
+    private Properties getEJBClientConfigurationProperties() throws Exception {
+        final Properties ejbClientContextProps = new Properties();
+        final String connectionName = "foo-bar-connection";
+        ejbClientContextProps.put("remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED", "false");
+        // add a property which lists the connections that we are configuring. In
+        // this example, we are just configuring a single connection named "foo-bar-connection"
+        ejbClientContextProps.put("remote.connections", connectionName);
+        // add a property which points to the host server of the "foo-bar-connection"
+        ejbClientContextProps.put("remote.connection." + connectionName + ".host", "localhost");
+        // add a property which points to the port on which the server is listening for EJB invocations
+        ejbClientContextProps.put("remote.connection." + connectionName + ".port", "7999");
+        // since we are connecting to a dummy server, we use anonymous user
+        ejbClientContextProps.put("remote.connection." + connectionName + ".connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS", "false");
+
+        return ejbClientContextProps;
+
+    }
+}

--- a/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorOne.java
+++ b/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorOne.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client.test.interceptor;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class InterceptorOne implements EJBClientInterceptor {
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        context.sendRequest();
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        final Object result = context.getResult();
+        if (result instanceof String) {
+            return this.getClass().getName() + " " + result;
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorThree.java
+++ b/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorThree.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client.test.interceptor;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class InterceptorThree implements EJBClientInterceptor {
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        context.sendRequest();
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        final Object result = context.getResult();
+        if (result instanceof String) {
+            return this.getClass().getName() + " " + result;
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorTwo.java
+++ b/src/test/java/org/jboss/ejb/client/test/interceptor/InterceptorTwo.java
@@ -1,0 +1,45 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2012, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client.test.interceptor;
+
+import org.jboss.ejb.client.EJBClientInterceptor;
+import org.jboss.ejb.client.EJBClientInvocationContext;
+
+/**
+ * @author Jaikiran Pai
+ */
+public class InterceptorTwo implements EJBClientInterceptor {
+    @Override
+    public void handleInvocation(EJBClientInvocationContext context) throws Exception {
+        context.sendRequest();
+    }
+
+    @Override
+    public Object handleInvocationResult(EJBClientInvocationContext context) throws Exception {
+        final Object result = context.getResult();
+        if (result instanceof String) {
+            return this.getClass().getName() + " " + result;
+        }
+        return result;
+    }
+}

--- a/src/test/resources/ejb-client-interceptors.org.jboss.ejb.client.EJBClientInterceptor
+++ b/src/test/resources/ejb-client-interceptors.org.jboss.ejb.client.EJBClientInterceptor
@@ -1,0 +1,2 @@
+org.jboss.ejb.client.test.interceptor.InterceptorTwo
+org.jboss.ejb.client.test.interceptor.InterceptorOne


### PR DESCRIPTION
The commit here adds support (and a testcase) for https://issues.jboss.org/browse/EJBCLIENT-61 which now allows EJB client interceptors to be auto registered with the EJB client context via service loader mechanism. Such interceptors which are auto registered via the service loader mechanism will be added to the end of the client interceptor chain, in the order they are found in the classpath. If the user application wants the interceptors to be somewhere else in the chain, then they can make use of the already available EJB client API(s) to do so.

The service loader will look for META-INF/services/org.jboss.ejb.client.EJBClientInterceptor file for registering these EJB client interceptors.
