### PR TITLE
[1.0] EJBCLIENT-72 Add support for transaction recovery of EJB XAResource(s)

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContextListener.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContextListener.java
@@ -37,4 +37,20 @@ public interface EJBClientContextListener {
      * @param ejbClientContext The EJB client context which was closed
      */
     void contextClosed(EJBClientContext ejbClientContext);
+
+    /**
+     * This method will be invoked when a {@link EJBReceiver} is registered to a {@link EJBClientContext}
+     *
+     * @param receiverContext The {@link EJBReceiverContext} which was associated to the {@link EJBClientContext} when the {@link EJBReceiver}
+     *                        was registered with the context
+     */
+    void receiverRegistered(final EJBReceiverContext receiverContext);
+
+    /**
+     * This method will be invoked when a {@link EJBReceiver} is unregistered from a {@link EJBClientContext}
+     *
+     * @param receiverContext The {@link EJBReceiverContext} which was disassociated from the {@link EJBClientContext}
+     *                        when the {@link EJBReceiver} was unregistered from the context
+     */
+    void receiverUnRegistered(final EJBReceiverContext receiverContext);
 }

--- a/src/main/java/org/jboss/ejb/client/EJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/EJBReceiver.java
@@ -23,6 +23,7 @@
 package org.jboss.ejb.client;
 
 import javax.transaction.xa.XAException;
+import javax.transaction.xa.Xid;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
@@ -185,6 +186,20 @@ public abstract class EJBReceiver extends Attachable {
     @SuppressWarnings("unused")
     protected void sendForget(final EJBReceiverContext context, final TransactionID transactionID) throws XAException {
         throw new XAException(XAException.XA_RBOTHER);
+    }
+
+    /**
+     * Send a transaction recover message with the <code>recoveryFlags</code>. The {@link EJBReceiver receiver} is expected to
+     * returns zero or more {@link Xid}s of the transaction branches that are currently in a prepared or heuristically completed state.
+     * See {@link javax.transaction.xa.XAResource#recover(int)} for more details.
+     *
+     * @param receiverContext The EJB receiver context
+     * @param recoveryFlags @see {@link javax.transaction.xa.XAResource#recover(int)}
+     * @return Returns zero or more {@link Xid}s of the transaction branches that are currently in a prepared or heuristically completed state.
+     * @throws XAException If an error occurs during the operation
+     */
+    protected Xid[] sendRecover(final EJBReceiverContext receiverContext, final String txParentNodeName, final int recoveryFlags) throws XAException {
+        return new Xid[0];
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/EJBReceiverContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBReceiverContext.java
@@ -48,7 +48,7 @@ public final class EJBReceiverContext extends Attachable implements Closeable {
         return clientContext;
     }
 
-    EJBReceiver getReceiver() {
+    public EJBReceiver getReceiver() {
         return receiver;
     }
 

--- a/src/main/java/org/jboss/ejb/client/RecoveryOnlyEJBXAResource.java
+++ b/src/main/java/org/jboss/ejb/client/RecoveryOnlyEJBXAResource.java
@@ -1,0 +1,125 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+
+/**
+ * An EJB {@link XAResource} which is supposed to be used only during transaction recovery.
+ *
+ * @author Jaikiran Pai
+ */
+class RecoveryOnlyEJBXAResource implements XAResource {
+
+    private final EJBReceiverContext receiverContext;
+    private final String transactionOriginNodeIdentifier;
+
+    /**
+     * @param transactionOriginNodeIdentifier
+     *                        The node identifier of the node from which the transaction originated
+     * @param receiverContext The EJB receiver context of the target EJB receiver/server which will be used to fetch the Xid(s)
+     *                        which need to be recovered
+     */
+    RecoveryOnlyEJBXAResource(final String transactionOriginNodeIdentifier, final EJBReceiverContext receiverContext) {
+        this.receiverContext = receiverContext;
+        this.transactionOriginNodeIdentifier = transactionOriginNodeIdentifier;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        final EJBReceiver receiver = receiverContext.getReceiver();
+        Logs.TXN.debug("Sending commit request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery. One phase? " + onePhase);
+        receiver.sendCommit(receiverContext, transactionID, onePhase);
+    }
+
+    @Override
+    public void end(Xid xid, int i) throws XAException {
+        Logs.TXN.debug("Ignoring end request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        final EJBReceiver receiver = receiverContext.getReceiver();
+        Logs.TXN.debug("Sending forget request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+        receiver.sendForget(receiverContext, transactionID);
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return 0;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xaResource) throws XAException {
+        if (xaResource == null) {
+            return false;
+        }
+        return EJBClientManagedTransactionContext.isEJBXAResourceClass(xaResource.getClass().getName());
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        Logs.TXN.debug("Prepare wasn't supposed to be called on " + this + " since this XAResource is only meant for transaction recovery. " +
+                "Ignoring the prepare request for xid " + xid);
+        return XA_OK;
+    }
+
+    @Override
+    public Xid[] recover(final int flags) throws XAException {
+        final EJBReceiver receiver = receiverContext.getReceiver();
+        Logs.TXN.debug("Send recover request for transaction origin node identifier " + transactionOriginNodeIdentifier + " to EJB receiver with node name " + receiver.getNodeName());
+        return receiver.sendRecover(receiverContext, transactionOriginNodeIdentifier, flags);
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        final EJBReceiver receiver = receiverContext.getReceiver();
+        Logs.TXN.debug("Sending rollback request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+        receiver.sendRollback(receiverContext, transactionID);
+    }
+
+    @Override
+    public boolean setTransactionTimeout(int i) throws XAException {
+        return false;
+    }
+
+    @Override
+    public void start(Xid xid, int i) throws XAException {
+        Logs.TXN.debug("Ignoring start request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("RecoveryOnlyEJBXAResource");
+        sb.append("{receiverContext=").append(receiverContext);
+        sb.append(", transactionOriginNodeIdentifier='").append(transactionOriginNodeIdentifier).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+}

--- a/src/main/java/org/jboss/ejb/client/RecoveryOnlySerializedEJBXAResource.java
+++ b/src/main/java/org/jboss/ejb/client/RecoveryOnlySerializedEJBXAResource.java
@@ -1,0 +1,185 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client;
+
+import javax.transaction.xa.XAException;
+import javax.transaction.xa.XAResource;
+import javax.transaction.xa.Xid;
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * A serialzed version of EJB XAResource which can only be used during transaction recovery
+ *
+ * @author Jaikiran Pai
+ */
+class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
+
+    private final String ejbReceiverNodeName;
+
+    RecoveryOnlySerializedEJBXAResource(final String ejbReceiverNodeName) {
+        this.ejbReceiverNodeName = ejbReceiverNodeName;
+    }
+
+    @Override
+    public void commit(Xid xid, boolean onePhase) throws XAException {
+        final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
+        if (receiverContexts.isEmpty()) {
+            Logs.TXN.debug("No EJB receiver contexts available for committing EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            throw new XAException(XAException.XA_RETRY);
+        }
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        for (final EJBReceiverContext receiverContext : receiverContexts) {
+            final EJBReceiver receiver = receiverContext.getReceiver();
+            Logs.TXN.debug(this + " sending commit request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery. One phase? " + onePhase);
+            receiver.sendCommit(receiverContext, transactionID, onePhase);
+        }
+    }
+
+    @Override
+    public void rollback(Xid xid) throws XAException {
+        final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
+        if (receiverContexts.isEmpty()) {
+            Logs.TXN.debug("No EJB receiver contexts available for rolling back EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            throw new XAException(XAException.XA_RETRY);
+        }
+
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        for (final EJBReceiverContext receiverContext : receiverContexts) {
+            final EJBReceiver receiver = receiverContext.getReceiver();
+            Logs.TXN.debug(this + " sending rollback request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+            receiver.sendRollback(receiverContext, transactionID);
+        }
+    }
+
+    @Override
+    public void forget(Xid xid) throws XAException {
+        final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
+        if (receiverContexts.isEmpty()) {
+            Logs.TXN.debug("No EJB receiver contexts available for forgetting EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            throw new XAException(XAException.XA_RETRY);
+        }
+        final XidTransactionID transactionID = new XidTransactionID(xid);
+        for (final EJBReceiverContext receiverContext : receiverContexts) {
+            final EJBReceiver receiver = receiverContext.getReceiver();
+            Logs.TXN.debug(this + " sending forget request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+            receiver.sendForget(receiverContext, transactionID);
+        }
+    }
+
+    @Override
+    public void end(Xid xid, int i) throws XAException {
+        Logs.TXN.debug("Ignoring end request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+    }
+
+    @Override
+    public int getTransactionTimeout() throws XAException {
+        return 0;
+    }
+
+    @Override
+    public boolean isSameRM(XAResource xaResource) throws XAException {
+        return false;
+    }
+
+    @Override
+    public int prepare(Xid xid) throws XAException {
+        Logs.TXN.debug("Prepare wasn't supposed to be called on " + this + " since this XAResource is only meant for transaction recovery. " +
+                "Ignoring the prepare request for xid " + xid);
+        return XA_OK;
+    }
+
+    @Override
+    public Xid[] recover(int i) throws XAException {
+        return new Xid[0];
+    }
+
+
+    @Override
+    public boolean setTransactionTimeout(int i) throws XAException {
+        return false;
+    }
+
+    @Override
+    public void start(Xid xid, int i) throws XAException {
+        Logs.TXN.debug("Ignoring start request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+    }
+
+
+    @Override
+    public String toString() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append("RecoveryOnlySerializedEJBXAResource");
+        sb.append("{ejbReceiverNodeName='").append(ejbReceiverNodeName).append('\'');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /**
+     * Listener which keeps track of the relevant EJB receivers which have been registered in various EJB client contexts.
+     * These receivers, if relevant, will then be used during transaction recovery.
+     */
+    static class ReceiverRegistrationListener implements EJBClientContextListener {
+
+        static final ReceiverRegistrationListener INSTANCE = new ReceiverRegistrationListener();
+
+        private final List<EJBReceiverContext> relevantReceiverContexts = Collections.synchronizedList(new ArrayList<EJBReceiverContext>());
+
+        private ReceiverRegistrationListener() {
+        }
+
+        @Override
+        public void contextClosed(EJBClientContext ejbClientContext) {
+        }
+
+        @Override
+        public void receiverRegistered(final EJBReceiverContext receiverContext) {
+            this.relevantReceiverContexts.add(receiverContext);
+        }
+
+        @Override
+        public void receiverUnRegistered(final EJBReceiverContext receiverContext) {
+            this.relevantReceiverContexts.remove(receiverContext);
+        }
+
+        private List<EJBReceiverContext> getRelevantReceiverContexts(final String nodeName) {
+            final List<EJBReceiverContext> eligibleReceiverContext = new ArrayList<EJBReceiverContext>();
+            synchronized (relevantReceiverContexts) {
+                for (final EJBReceiverContext receiverContext : relevantReceiverContexts) {
+                    if (receiverContext == null) {
+                        continue;
+                    }
+                    if (nodeName == null) {
+                        eligibleReceiverContext.add(receiverContext);
+                    } else if (nodeName.equals(receiverContext.getReceiver().getNodeName())) {
+                        eligibleReceiverContext.add(receiverContext);
+                    }
+                }
+            }
+            return eligibleReceiverContext;
+        }
+
+    }
+}

--- a/src/main/java/org/jboss/ejb/client/TransactionRecoveryContextInitializer.java
+++ b/src/main/java/org/jboss/ejb/client/TransactionRecoveryContextInitializer.java
@@ -1,0 +1,38 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client;
+
+/**
+ * A {@link EJBClientContextInitializer} which sets up the {@link EJBClientContext} with the relevant information so that the transaction
+ * recovery process for EJB XAResource(s) can be functional
+ *
+ * @author Jaikiran Pai
+ */
+public class TransactionRecoveryContextInitializer implements EJBClientContextInitializer {
+    @Override
+    public void initialize(EJBClientContext context) {
+        // we register a EJB client context listener which keeps track of the registered EJB receivers, so that those
+        // receivers can be used during transaction recovery process for checking any recoverable Xid(s)
+        context.registerEJBClientContextListener(RecoveryOnlySerializedEJBXAResource.ReceiverRegistrationListener.INSTANCE);
+    }
+}

--- a/src/main/java/org/jboss/ejb/client/XidTransactionID.java
+++ b/src/main/java/org/jboss/ejb/client/XidTransactionID.java
@@ -53,7 +53,7 @@ public final class XidTransactionID extends TransactionID {
         }
     }
 
-    XidTransactionID(final Xid original) {
+    public XidTransactionID(final Xid original) {
         this(encode(original));
     }
 

--- a/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
@@ -324,6 +324,9 @@ class ChannelAssociation {
             case 0x18:
                 // node removal message handler
                 return new ClusterNodeRemovalHandler(this);
+            case 0x1A:
+                // transaction recovery response
+                return new TransactionRecoveryResponseHandler(this, this.marshallerFactory);
             default:
                 return null;
         }

--- a/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
@@ -27,6 +27,7 @@ import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBClientContextIdentifier;
 import org.jboss.ejb.client.EJBClientContextListener;
 import org.jboss.ejb.client.EJBReceiver;
+import org.jboss.ejb.client.EJBReceiverContext;
 import org.jboss.ejb.client.IdentityEJBClientContextSelector;
 import org.jboss.ejb.client.Logs;
 import org.jboss.logging.Logger;
@@ -123,7 +124,7 @@ public class ConfigBasedEJBClientContextSelector implements IdentityEJBClientCon
             final int port = connectionConfiguration.getPort();
             final int MAX_RECONNECT_ATTEMPTS = 65535; // TODO: Let's keep this high for now and later allow configuration and a smaller default value
             // create a re-connect handler (which will be used on connection breaking down)
-            final ReconnectHandler reconnectHandler =  new EJBClientContextConnectionReconnectHandler(ejbClientContext, endpoint, host, port, connectionConfiguration, MAX_RECONNECT_ATTEMPTS);
+            final ReconnectHandler reconnectHandler = new EJBClientContextConnectionReconnectHandler(ejbClientContext, endpoint, host, port, connectionConfiguration, MAX_RECONNECT_ATTEMPTS);
             try {
                 // wait for the connection to be established
                 final Connection connection = this.remotingConnectionManager.getConnection(endpoint, host, port, connectionConfiguration);
@@ -173,6 +174,14 @@ public class ConfigBasedEJBClientContextSelector implements IdentityEJBClientCon
             // for the EJB client context that just closed
             remotingConnectionManager.safeClose();
             remotingEndpointManager.safeClose();
+        }
+
+        @Override
+        public void receiverRegistered(EJBReceiverContext receiverContext) {
+        }
+
+        @Override
+        public void receiverUnRegistered(EJBReceiverContext receiverContext) {
         }
     }
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingCleanupHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingCleanupHandler.java
@@ -24,6 +24,8 @@ package org.jboss.ejb.client.remoting;
 
 import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBClientContextListener;
+import org.jboss.ejb.client.EJBReceiver;
+import org.jboss.ejb.client.EJBReceiverContext;
 import org.jboss.logging.Logger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
@@ -49,6 +51,16 @@ class RemotingCleanupHandler implements EJBClientContextListener {
     @Override
     public void contextClosed(EJBClientContext ejbClientContext) {
         this.closeAll();
+    }
+
+    @Override
+    public void receiverRegistered(final EJBReceiverContext receiverContext) {
+        // we don't have to do anything
+    }
+
+    @Override
+    public void receiverUnRegistered(final EJBReceiverContext receiverContext) {
+        // we don't have to do anything
     }
 
     void addEndpoint(final Endpoint endpoint) {

--- a/src/main/java/org/jboss/ejb/client/remoting/TransactionMessageWriter.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/TransactionMessageWriter.java
@@ -38,6 +38,7 @@ class TransactionMessageWriter extends AbstractMessageWriter {
     private static final byte HEADER_TX_PREPARE_MESSAGE = 0x11;
     private static final byte HEADER_TX_FORGET_MESSAGE = 0x12;
     private static final byte HEADER_TX_BEFORE_COMPLETION_MESSAGE = 0x13;
+    private static final byte HEADER_TX_RECOVER_MESSAGE = 0x19;
 
 
     void writeTxCommit(final DataOutput output, final short invocationId, final TransactionID transactionID, final boolean onePhaseCommit) throws IOException {
@@ -101,4 +102,16 @@ class TransactionMessageWriter extends AbstractMessageWriter {
         // write the transaction id bytes
         output.write(transactionIDBytes);
     }
+
+    void writeTxRecover(final DataOutput output, final short invocationId, final String txParentNodeName, final int flags) throws IOException {
+        // write the header
+        output.writeByte(HEADER_TX_RECOVER_MESSAGE);
+        // write the invocation id
+        output.writeShort(invocationId);
+        // write the node name of the transaction parent
+        output.writeUTF(txParentNodeName);
+        // the recovery flags
+        output.writeInt(flags);
+    }
+
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/TransactionRecoveryResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/TransactionRecoveryResponseHandler.java
@@ -1,0 +1,97 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2013, Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.jboss.ejb.client.remoting;
+
+import org.jboss.ejb.client.EJBReceiverInvocationContext;
+import org.jboss.ejb.client.XidTransactionID;
+import org.jboss.marshalling.MarshallerFactory;
+import org.jboss.marshalling.Unmarshaller;
+import org.jboss.remoting3.MessageInputStream;
+
+import javax.transaction.xa.Xid;
+import java.io.DataInputStream;
+import java.io.IOException;
+
+/**
+ * Responsible for handling the response returned back for a transaction recovery request
+ *
+ * @author Jaikiran Pai
+ */
+class TransactionRecoveryResponseHandler extends ProtocolMessageHandler {
+
+    private final ChannelAssociation channelAssociation;
+    private final MarshallerFactory marshallerFactory;
+
+    TransactionRecoveryResponseHandler(final ChannelAssociation channelAssociation, final MarshallerFactory marshallerFactory) {
+        this.channelAssociation = channelAssociation;
+        this.marshallerFactory = marshallerFactory;
+    }
+
+    @Override
+    protected void processMessage(final MessageInputStream messageInputStream) throws IOException {
+        // read the invocation id
+        final DataInputStream dataInputStream = new DataInputStream(messageInputStream);
+        try {
+            final short invocationId = dataInputStream.readShort();
+            final int numXidsToRecover = PackedInteger.readPackedInteger(dataInputStream);
+            if (numXidsToRecover > 0) {
+                // prepare the unmarshaller
+                final Unmarshaller unmarshaller = this.prepareForUnMarshalling(marshallerFactory, dataInputStream);
+                final Xid[] xidsToRecover = new Xid[numXidsToRecover];
+                for (int i = 0; i < numXidsToRecover; i++) {
+                    final XidTransactionID xidTransactionID = (XidTransactionID) unmarshaller.readObject();
+                    xidsToRecover[i] = xidTransactionID.getXid();
+                }
+                // finish unmarshalling
+                unmarshaller.finish();
+                // let the waiting invocation know that the result is ready
+                this.channelAssociation.resultReady(invocationId, new TxRecoveryResultProducer(xidsToRecover));
+            } else {
+                // let the waiting invocation know that the result is ready
+                this.channelAssociation.resultReady(invocationId, new TxRecoveryResultProducer(new Xid[0]));
+            }
+        } catch (ClassNotFoundException e) {
+            throw new IOException(e);
+        } finally {
+            dataInputStream.close();
+        }
+    }
+
+    private class TxRecoveryResultProducer implements EJBReceiverInvocationContext.ResultProducer {
+
+        private Xid[] xidsToRecover;
+
+        TxRecoveryResultProducer(final Xid[] xidsToRecover) {
+            this.xidsToRecover = xidsToRecover;
+        }
+
+        @Override
+        public Object getResult() throws Exception {
+            return this.xidsToRecover;
+        }
+
+        @Override
+        public void discardResult() {
+        }
+    }
+}

--- a/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientContextInitializer
+++ b/src/main/resources/META-INF/services/org.jboss.ejb.client.EJBClientContextInitializer
@@ -1,1 +1,3 @@
 org.jboss.ejb.client.DefaultInterceptorsClientContextInitializer
+org.jboss.ejb.client.TransactionRecoveryContextInitializer
+


### PR DESCRIPTION
The commit here adds support for transaction recovery of remote EJB XAResource(s) as required in https://issues.jboss.org/browse/EJBCLIENT-72
