### PR TITLE
[master branch] Fix for EJBCLIENT-79

### DIFF
--- a/src/main/java/org/jboss/ejb/client/RequestSendFailedException.java
+++ b/src/main/java/org/jboss/ejb/client/RequestSendFailedException.java
@@ -1,0 +1,33 @@
+package org.jboss.ejb.client;
+
+/**
+ * An exception (typically) thrown by {@link EJBReceiver}s if the receiver couldn't successfully handle a request.
+ *
+ * @author: Jaikiran Pai
+ */
+public class RequestSendFailedException extends RuntimeException {
+
+    /**
+     * The node name of the EJB receiver which failed to handle the request
+     */
+    private final String failedNodeName;
+
+    /**
+     * @param failedNodeName The node name of the EJB receiver which failed to handle the request
+     * @param failureMessage The exception message
+     * @param cause          The exception which caused this failure
+     */
+    public RequestSendFailedException(final String failedNodeName, final String failureMessage, final Throwable cause) {
+        super(failureMessage, cause);
+        this.failedNodeName = failedNodeName;
+    }
+
+    /**
+     * Returns the node name of the EJB receiver which failed to handle the request
+     *
+     * @return
+     */
+    String getFailedNodeName() {
+        return this.failedNodeName;
+    }
+}


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=957170
https://bugzilla.redhat.com/show_bug.cgi?id=957171

bugzillas exposed certain use cases where the EJB client API wasn't retrying a failed operation, even though it could potentially do it. https://issues.jboss.org/browse/EJBCLIENT-79 summarizes the use cases which were missing the potential retry. The commit here fixes those issues.
