### PR TITLE
EJBCLIENT-83 Fix EJBClient.asynchronous() method

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClient.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClient.java
@@ -68,7 +68,7 @@ public final class EJBClient {
         if (invocationHandler instanceof EJBInvocationHandler) {
             final EJBInvocationHandler remoteInvocationHandler = (EJBInvocationHandler) invocationHandler;
             // determine proxy "type", return existing instance if it's already async
-            if (true) {
+            if (remoteInvocationHandler.isAsyncHandler()) {
                 return proxy;
             } else {
                 return (T) Proxy.newProxyInstance(proxy.getClass().getClassLoader(), proxy.getClass().getInterfaces(), remoteInvocationHandler.getAsyncHandler());

--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -278,6 +278,10 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
         return async ? this : new EJBInvocationHandler<T>(this);
     }
 
+    boolean isAsyncHandler() {
+        return this.async;
+    }
+
     EJBLocator<T> getLocator() {
         return locator;
     }

--- a/src/test/java/org/jboss/ejb/client/test/async/ExceptionThrower.java
+++ b/src/test/java/org/jboss/ejb/client/test/async/ExceptionThrower.java
@@ -1,0 +1,9 @@
+package org.jboss.ejb.client.test.async;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public interface ExceptionThrower {
+
+    void justThrowBackSomeException();
+}

--- a/src/test/java/org/jboss/ejb/client/test/async/ExceptionThrowingBean.java
+++ b/src/test/java/org/jboss/ejb/client/test/async/ExceptionThrowingBean.java
@@ -1,0 +1,13 @@
+package org.jboss.ejb.client.test.async;
+
+/**
+ * @author: Jaikiran Pai
+ */
+public class ExceptionThrowingBean implements ExceptionThrower {
+
+
+    @Override
+    public void justThrowBackSomeException() {
+        throw new RuntimeException("Intentionally thrown exception from " + this.getClass().getName());
+    }
+}


### PR DESCRIPTION
The commit here fixes the issue reported in https://issues.jboss.org/browse/EJBCLIENT-83 where the call to EJBClient.asynchronous(proxy) method to get a asynchronous proxy, would just return back the original EJB proxy.
