### PR TITLE
Implementation of EJBCLIENT-82 

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientConfiguration.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientConfiguration.java
@@ -22,10 +22,11 @@
 
 package org.jboss.ejb.client;
 
-import org.xnio.OptionMap;
+import java.util.Iterator;
 
 import javax.security.auth.callback.CallbackHandler;
-import java.util.Iterator;
+
+import org.xnio.OptionMap;
 
 /**
  * {@link EJBClientConfiguration} is responsible for providing the configurations that will be used
@@ -162,6 +163,17 @@ public interface EJBClientConfiguration {
          * @return
          */
         OptionMap getChannelCreationOptions();
+
+        /**
+         * If this method returns true, then the EJB client API will try and connect to the destination host "eagerly". when the {@link EJBClientContext}
+         * is being created out of the {@link EJBClientConfiguration} to which this connection configuration belongs.
+         * <p/>
+         * On the other hand, if this method returns false, then the EJB client API will try to connect to the destination host only if no other node/EJBReceiver within the EJB client context
+         * can handle a EJB invocation request. i.e. it tries to establish the connection lazily/on-demand.
+         *
+         * @return
+         */
+        boolean isConnectEagerly();
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/PropertiesBasedEJBClientConfiguration.java
+++ b/src/main/java/org/jboss/ejb/client/PropertiesBasedEJBClientConfiguration.java
@@ -76,6 +76,8 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
     private static final String REMOTE_CONNECTION_PROVIDER_CREATE_OPTIONS_PREFIX = "remote.connectionprovider.create.options.";
 
     private static final String PROPERTY_KEY_REMOTE_CONNECTIONS = "remote.connections";
+    private static final String PROPERTY_KEY_REMOTE_CONNECTIONS_CONNECT_EAGER = "remote.connections.connect.eager";
+
     // The default options that will be used (unless overridden by the config file) while creating a connection
     private static final OptionMap DEFAULT_CONNECTION_CREATION_OPTIONS = OptionMap.EMPTY;
     private static final long DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS = 5000;
@@ -452,6 +454,20 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
             logger.debug("No remoting connections configured in properties");
             return;
         }
+        // make note of whether the connection attempts are to be eager or lazy for all listed connections (unless overridden at the specific connection configuration)
+        final Object connectEagerValue = ejbReceiversConfigurationProperties.get(PROPERTY_KEY_REMOTE_CONNECTIONS_CONNECT_EAGER);
+        final boolean connectEager;
+        if (connectEagerValue == null) {
+            // by default we connect eagerly
+            connectEager = true;
+        } else {
+            if (connectEagerValue instanceof String) {
+                connectEager = Boolean.valueOf(((String) connectEagerValue).trim());
+            } else {
+                // default to true
+                connectEager = true;
+            }
+        }
         // parse the comma separated string of connection names
         final StringTokenizer tokenizer = new StringTokenizer(remoteConnectionNames, ",");
         while (tokenizer.hasMoreTokens()) {
@@ -461,7 +477,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
             }
             RemotingConnectionConfiguration connectionConfiguration = null;
             try {
-                connectionConfiguration = this.createConnectionConfiguration(connectionName);
+                connectionConfiguration = this.createConnectionConfiguration(connectionName, connectEager);
             } catch (Exception e) {
                 logger.warn("Could not create connection for connection named " + connectionName, e);
             }
@@ -474,7 +490,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         }
     }
 
-    private RemotingConnectionConfiguration createConnectionConfiguration(final String connectionName) throws IOException, URISyntaxException {
+    private RemotingConnectionConfiguration createConnectionConfiguration(final String connectionName, final boolean defaultConnectEager) throws IOException, URISyntaxException {
         final String connectionSpecificPrefix = this.getConnectionSpecificPrefix(connectionName);
         final Map<String, String> connectionSpecificProps = this.getPropertiesWithPrefix(connectionSpecificPrefix);
         if (connectionSpecificProps.isEmpty()) {
@@ -520,6 +536,15 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
                 Logs.MAIN.incorrectConnectionTimeoutValueForConnection(connectionTimeoutValue, connectionName, String.valueOf(DEFAULT_CONNECTION_TIMEOUT_IN_MILLIS));
             }
         }
+        // connect eagerly or lazily
+        final String connectEagerValue = connectionSpecificProps.get("connect.eager");
+        final boolean connectEagerly;
+        if (connectEagerValue == null || connectEagerValue.trim().isEmpty()) {
+            // default to the value that may have been set for all connections
+            connectEagerly = defaultConnectEager;
+        } else {
+            connectEagerly = Boolean.valueOf(connectEagerValue.trim());
+        }
         // create the CallbackHandler for this connection configuration
         final CallbackHandler callbackHandler = createCallbackHandler(connectionSpecificProps, this.getDefaultCallbackHandler());
         connectOptions = RemotingConnectionUtil.addSilentLocalAuthOptionsIfApplicable(callbackHandler, connectOptions);
@@ -527,7 +552,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         // Channel creation options for this connection
         final String channelOptionsPrefix = this.getConnectionSpecificChannelOptionsPrefix(connectionName);
         final OptionMap channelOptions = getOptionMapFromProperties(ejbReceiversConfigurationProperties, channelOptionsPrefix, getClientClassLoader());
-        return new RemotingConnectionConfigurationImpl(protocol, host, port, connectOptions, connectionTimeout, callbackHandler, channelOptions);
+        return new RemotingConnectionConfigurationImpl(protocol, host, port, connectOptions, connectionTimeout, callbackHandler, channelOptions, connectEagerly);
 
     }
 
@@ -717,9 +742,11 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         final long connectionTimeout;
         final CallbackHandler callbackHandler;
         final OptionMap channelCreationOptions;
+        final boolean connectEagerly;
 
         RemotingConnectionConfigurationImpl(final String protocol, final String host, final int port, final OptionMap connectionCreationOptions,
-                                            final long connectionTimeout, final CallbackHandler callbackHandler, final OptionMap channelCreationOptions) {
+                                            final long connectionTimeout, final CallbackHandler callbackHandler, final OptionMap channelCreationOptions,
+                                            final boolean connectEagerly) {
             this.protocol = protocol;
             this.host = host;
             this.port = port;
@@ -727,6 +754,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
             this.connectionTimeout = connectionTimeout;
             this.callbackHandler = callbackHandler;
             this.channelCreationOptions = channelCreationOptions == null ? OptionMap.EMPTY : channelCreationOptions;
+            this.connectEagerly = connectEagerly;
         }
 
         @Override
@@ -757,6 +785,11 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         @Override
         public OptionMap getChannelCreationOptions() {
             return this.channelCreationOptions;
+        }
+
+        @Override
+        public boolean isConnectEagerly() {
+            return connectEagerly;
         }
 
         @Override
@@ -841,6 +874,12 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         public OptionMap getChannelCreationOptions() {
             return this.channelCreationOptions;
         }
+
+        @Override
+        public boolean isConnectEagerly() {
+            // connecting to cluster nodes is always on-demand and not eager. So return false.
+            return false;
+        }
     }
 
     private class ClusterNodeConfigurationImpl implements ClusterNodeConfiguration {
@@ -883,6 +922,12 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
         @Override
         public OptionMap getChannelCreationOptions() {
             return this.channelCreationOptions;
+        }
+
+        @Override
+        public boolean isConnectEagerly() {
+            // connecting to cluster node is always on-demand and not eager. So return false.
+            return false;
         }
     }
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionClusterNodeManager.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionClusterNodeManager.java
@@ -22,6 +22,8 @@
 
 package org.jboss.ejb.client.remoting;
 
+import javax.security.auth.callback.CallbackHandler;
+
 import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.ClusterNodeManager;
 import org.jboss.ejb.client.DefaultCallbackHandler;
@@ -32,8 +34,6 @@ import org.jboss.logging.Logger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.OptionMap;
-
-import javax.security.auth.callback.CallbackHandler;
 
 /**
  * A {@link RemotingConnectionClusterNodeManager} uses JBoss Remoting to create a {@link EJBReceiver}
@@ -150,6 +150,12 @@ class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
         @Override
         public OptionMap getChannelCreationOptions() {
             return this.channelCreationOptions;
+        }
+
+        @Override
+        public boolean isConnectEagerly() {
+            // connecting to cluster node is always on-demand and not eager. So return false.
+            return false;
         }
     }
 }

--- a/src/test/java/org/jboss/ejb/client/test/properties/PropertiesBasedEJBClientConfigurationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/properties/PropertiesBasedEJBClientConfigurationTestCase.java
@@ -89,6 +89,72 @@ public class PropertiesBasedEJBClientConfigurationTestCase {
 
     }
 
+
+    /**
+     * Tests that the <code>remote.connection.&lt;connection-name&gt;.connect.eager</code> property can be used to control the connection creation behaviour.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLazyConnectionConfiguration() throws Exception {
+        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("lazy-connection-jboss-ejb-client.properties");
+        final Properties clientProperties = new Properties();
+        clientProperties.load(inputStream);
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(clientProperties);
+
+        // connection configurations
+        final Iterator<EJBClientConfiguration.RemotingConnectionConfiguration> connectionConfigs = ejbClientConfiguration.getConnectionConfigurations();
+        Assert.assertNotNull("No connection configurations found", connectionConfigs);
+
+        while (connectionConfigs.hasNext()) {
+            final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig = connectionConfigs.next();
+            final String hostName = connectionConfig.getHost();
+            Assert.assertNotNull("Host name was null in connection configuration", hostName);
+            if ("lazy".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy", connectionConfig.isConnectEagerly());
+            } else if ("eager".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager", connectionConfig.isConnectEagerly());
+            } else if ("default".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager (by default)", connectionConfig.isConnectEagerly());
+            }
+        }
+
+    }
+
+    /**
+     * Tests that the properties configuration can be used to specify <code>remote.connections.connect.eager=false</code> as a default to be applied for all listed
+     * connection configurations (unless it's overridden for a specific connection configuration)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultLazyConnectionConfiguration() throws Exception {
+        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("default-lazy-connections-jboss-ejb-client.properties");
+        final Properties clientProperties = new Properties();
+        clientProperties.load(inputStream);
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(clientProperties);
+
+        // connection configurations
+        final Iterator<EJBClientConfiguration.RemotingConnectionConfiguration> connectionConfigs = ejbClientConfiguration.getConnectionConfigurations();
+        Assert.assertNotNull("No connection configurations found", connectionConfigs);
+
+        while (connectionConfigs.hasNext()) {
+            final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig = connectionConfigs.next();
+            final String hostName = connectionConfig.getHost();
+            Assert.assertNotNull("Host name was null in connection configuration", hostName);
+            if ("lazy".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy", connectionConfig.isConnectEagerly());
+            } else if ("eager".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager", connectionConfig.isConnectEagerly());
+            } else if ("default".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy (by default)", connectionConfig.isConnectEagerly());
+            }
+        }
+
+    }
+
     private void testConnectionConfigOne(final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig) {
         // port
         final int port = connectionConfig.getPort();

--- a/src/test/resources/default-lazy-connections-jboss-ejb-client.properties
+++ b/src/test/resources/default-lazy-connections-jboss-ejb-client.properties
@@ -1,0 +1,38 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+endpoint.name=test-endpoint-name
+
+remote.connections=a,b,c
+remote.connections.connect.eager=false
+
+remote.connection.a.host=default
+remote.connection.a.port=6999
+
+remote.connection.b.host=eager
+remote.connection.b.port=4999
+remote.connection.b.connect.eager=true
+
+remote.connection.c.host=lazy
+remote.connection.c.port=4999
+remote.connection.c.connect.eager=false
+

--- a/src/test/resources/lazy-connection-jboss-ejb-client.properties
+++ b/src/test/resources/lazy-connection-jboss-ejb-client.properties
@@ -1,0 +1,35 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+endpoint.name=test-endpoint-name
+
+remote.connections=lazy,default,eager
+
+remote.connection.lazy.host=lazy
+remote.connection.lazy.port=6999
+remote.connection.lazy.connect.eager=false
+
+remote.connection.eager.host=eager
+remote.connection.eager.port=4999
+remote.connection.eager.connect.eager=true
+
+remote.connection.default.host=default
+remote.connection.default.port=8999


### PR DESCRIPTION
The commit here introduces the feature to allow a way to specify whether a particular connection configuration in a EJB client context, needs to be establish a connection eagerly or lazily. This was requested in https://issues.jboss.org/browse/EJBCLIENT-82.

By default, connections listed in the configuration will be created eagerly like before. However, users can use the following property style to mark a particular connection to be lazy:

```
     # This marks the connection named "connection-name" to be connected lazily
     remote.connection.<connection-name>.connect.eager=false
```

Furthermore, all connections listed can be defaulted to lazy by using:

```
     # All listed connection configurations will by default be lazily connected due to this property
    remote.connections.connect.eager=false
```

The *.connect.eager property accepts a value of either true or false.

This commit also contains a testcase to test this feature.
