### PR TITLE
[EJBCLIENT-107] Support affinity change for StatelessEJBLocator

### DIFF
--- a/src/main/java/org/jboss/ejb/client/StatelessEJBLocator.java
+++ b/src/main/java/org/jboss/ejb/client/StatelessEJBLocator.java
@@ -45,6 +45,20 @@ public final class StatelessEJBLocator<T> extends EJBLocator<T> {
     }
 
     /**
+     * Construct a new instance.
+     *
+     * @param viewType     the view type
+     * @param appName      the application name
+     * @param moduleName   the module name
+     * @param beanName     the bean name
+     * @param distinctName the distinct name
+     * @param affinity     the affinity
+     */
+    public StatelessEJBLocator(final Class<T> viewType, final String appName, final String moduleName, final String beanName, final String distinctName, final Affinity affinity) {
+        super(viewType, appName, moduleName, beanName, distinctName, affinity);
+    }
+
+    /**
      * Get the hash code for this instance.
      *
      * @return the hash code for this instance


### PR DESCRIPTION
This is mostly useful for invocation of singleton beans in a cluster to
specify particular node on which the call should be performed.
