### PR TITLE
[EJBCLIENT-109] At MethodInvocationResponseHandler$MethodInvocationRespo...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/Logs.java
+++ b/src/main/java/org/jboss/ejb/client/Logs.java
@@ -33,6 +33,7 @@ import org.jboss.remoting3.Channel;
 import javax.naming.NamingException;
 import javax.transaction.NotSupportedException;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -293,4 +294,8 @@ public interface Logs extends BasicLogger {
 
     @Message(id = 405, value = "An EJB client context is already registered for EJB client context identifier %s")
     IllegalStateException ejbClientContextAlreadyRegisteredForIdentifier(EJBClientContextIdentifier identifier);
+
+    @LogMessage(level = INFO)
+    @Message(id = 406, value = "Unexpected exception when discarding invocation result")
+    void exceptionOnDiscardResult(@Cause IOException exception);
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/MethodInvocationResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/MethodInvocationResponseHandler.java
@@ -26,6 +26,7 @@ import org.jboss.ejb.client.Affinity;
 import org.jboss.ejb.client.AttachmentKeys;
 import org.jboss.ejb.client.EJBClientInvocationContext;
 import org.jboss.ejb.client.EJBReceiverInvocationContext;
+import org.jboss.ejb.client.Logs;
 import org.jboss.logging.Logger;
 import org.jboss.marshalling.MarshallerFactory;
 import org.jboss.marshalling.Unmarshaller;
@@ -125,6 +126,22 @@ class MethodInvocationResponseHandler extends ProtocolMessageHandler {
 
         @Override
         public void discardResult() {
+            try {
+                // skipping all bytes from input, until we read the end of the message,
+                // is going to trigger an acknowledgement of those received bytes to
+                // to the server, thus garanteeing the connection is kept consistent
+                while (input.read() != -1) {
+                    input.skip(input.available());
+                }
+            } catch (IOException e) {
+                Logs.REMOTING.exceptionOnDiscardResult(e);
+            } finally {
+                try {
+                    input.close();
+                } catch (IOException e) {
+                    Logs.REMOTING.exceptionOnDiscardResult(e);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
...nseProducer.discardResult: skip the bytes in the response, and close the DataInputStream afterwards

This is the fix for EJBCLIENT-109.

The only thing I am uncertain about the fix is the treatment of the exception, if this needs to be changed, please let me know.
