### PR TITLE
[EJBCLIENT-109] At MethodInvocationResponseHandler$MethodInvocationRespo...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/Logs.java
+++ b/src/main/java/org/jboss/ejb/client/Logs.java
@@ -33,6 +33,7 @@ import org.jboss.remoting3.Channel;
 import javax.naming.NamingException;
 import javax.transaction.NotSupportedException;
 
+import java.io.IOException;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
@@ -293,4 +294,8 @@ public interface Logs extends BasicLogger {
 
     @Message(id = 405, value = "An EJB client context is already registered for EJB client context identifier %s")
     IllegalStateException ejbClientContextAlreadyRegisteredForIdentifier(EJBClientContextIdentifier identifier);
+
+    @LogMessage(level = INFO)
+    @Message(id = 406, value = "Unexpected exception when discarding invocation result")
+    void exceptionOnDiscardResult(@Cause IOException exception);
 }


### PR DESCRIPTION
...nseProducer.discardResult: skip the bytes in the response, and close the DataInputStream afterwards

This is the fix for EJBCLIENT-109.

The only thing I am uncertain about the fix is the treatment of the exception, if this needs to be changed, please let me know.
