### PR TITLE
[EJBCLIENT-78] if shutdown() is called remove the shutdown task if the s...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/ConnectionPool.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ConnectionPool.java
@@ -58,8 +58,10 @@ class ConnectionPool {
 
     static final ConnectionPool INSTANCE = new ConnectionPool();
 
+    static final Thread SHUTDOWN_TASK = new Thread(new ShutdownTask(INSTANCE));
+
     static {
-        SecurityActions.addShutdownHook(new Thread(new ShutdownTask(INSTANCE)));
+        SecurityActions.addShutdownHook(SHUTDOWN_TASK);
     }
 
     private final ConcurrentMap<CacheKey, PooledConnection> cache = new ConcurrentHashMap<CacheKey, PooledConnection>();
@@ -112,6 +114,9 @@ class ConnectionPool {
             safeClose(connection);
         }
         cache.clear();
+
+        if(Thread.currentThread().getId() != SHUTDOWN_TASK.getId())
+            SecurityActions.removeShutdownHook(SHUTDOWN_TASK);
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/remoting/EndpointPool.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/EndpointPool.java
@@ -64,8 +64,10 @@ class EndpointPool {
 
     static final EndpointPool INSTANCE = new EndpointPool();
 
+    static final Thread SHUTDOWN_TASK = new Thread(new ShutdownTask(INSTANCE));
+
     static {
-        SecurityActions.addShutdownHook(new Thread(new ShutdownTask(INSTANCE)));
+        SecurityActions.addShutdownHook(SHUTDOWN_TASK);
     }
 
     private final ConcurrentMap<CacheKey, PooledEndpoint> cache = new ConcurrentHashMap<CacheKey, PooledEndpoint>();
@@ -111,6 +113,9 @@ class EndpointPool {
             safeClose(entry.getValue().underlyingEndpoint);
         }
         cache.clear();
+
+        if(Thread.currentThread().getId() != SHUTDOWN_TASK.getId())
+            SecurityActions.removeShutdownHook(SHUTDOWN_TASK);
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/remoting/SecurityActions.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/SecurityActions.java
@@ -100,6 +100,19 @@ final class SecurityActions {
         }
     }
 
+    static Boolean removeShutdownHook(final Thread shutdownHook) {
+        final SecurityManager sm = System.getSecurityManager();
+        if (sm == null) {
+            return Runtime.getRuntime().removeShutdownHook(shutdownHook);
+        } else {
+            return AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
+                public Boolean run() {
+                    return Runtime.getRuntime().removeShutdownHook(shutdownHook);
+                }
+            });
+        }
+    }
+
     private SecurityActions() {
 
     }


### PR DESCRIPTION
...hutdown task is not initiating the shutdown()
https://issues.jboss.org/browse/EJBCLIENT-78
Use case would be war packaging jboss-client.jar running in a non JBoss AS 7 container and being how deployed in which case a new classloader would be created and another thread registered as shutdown handler
