### PR TITLE
[EJBCLIENT-121] Handle reconnection in the presence of concurrent invocations

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -42,7 +42,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.jboss.ejb.client.remoting.ConfigBasedEJBClientContextSelector;
 import org.jboss.ejb.client.remoting.ReconnectHandler;
@@ -104,7 +108,10 @@ public final class EJBClientContext extends Attachable implements Closeable {
 
     private final Collection<EJBClientContextListener> ejbClientContextListeners = Collections.synchronizedSet(new HashSet<EJBClientContextListener>());
     private volatile boolean closed;
-    private volatile boolean attemptingReconnect;
+
+    private final AtomicBoolean attemptingReconnect = new AtomicBoolean(false);
+    private final Lock reconnectCompletedLock = new ReentrantLock();
+    private final Condition reconnectCompletedCondition = reconnectCompletedLock.newCondition();
 
     private EJBClientContext(final EJBClientConfiguration ejbClientConfiguration) {
         this.ejbClientConfiguration = ejbClientConfiguration;
@@ -1132,45 +1139,76 @@ public final class EJBClientContext extends Attachable implements Closeable {
 
     private void attemptReconnections() {
         final CountDownLatch reconnectTasksCompletionNotifierLatch;
-        synchronized(this) {
+        final List<ReconnectHandler> reconnectHandlersToAttempt;
+
+        // check for circumstances where we don't want to attempt reconnection
+        synchronized (this) {
+            // no need to reconnect if the context is closed
             if (this.closed) {
                 if (logger.isTraceEnabled()) {
                     logger.trace("EJB client context " + this + " has been closed, no reconnections, to register EJB receivers, will be attempted");
                 }
                 return;
             }
-            if(this.attemptingReconnect) {
-                if (logger.isTraceEnabled()) {
-                    logger.trace("EJB client context " + this + " is already attempting to reconnect");
-                }
-                return;
-            }
-
-            this.attemptingReconnect = true;
-
-            final List<ReconnectHandler> reconnectHandlersToAttempt = new ArrayList<ReconnectHandler>(this.reconnectHandlers);
+            // no need to attempt reconnection of no handlers
+            reconnectHandlersToAttempt = new ArrayList<ReconnectHandler>(this.reconnectHandlers);
             if (reconnectHandlersToAttempt.isEmpty()) {
                 // no re-connections to attempt, just return
                 return;
+            }
+        }
+
+        // first thread through performs the reconnect attempt, others block
+        if (attemptingReconnect.compareAndSet(false, true)) {
+            // initiate the reconnection tasks
+            if (logger.isTraceEnabled()) {
+                logger.trace("EJB client context " + this + " attempting reconnect on thread " + Thread.currentThread().getName());
             }
             reconnectTasksCompletionNotifierLatch = new CountDownLatch(reconnectHandlersToAttempt.size());
             for (final ReconnectHandler reconnectHandler : reconnectHandlersToAttempt) {
                 // submit each of the re-connection tasks
                 this.ejbClientContextTasksExecutorService.submit(new ReconnectAttempt(reconnectHandler, reconnectTasksCompletionNotifierLatch, this));
             }
-        }
-        // wait for all tasks to complete (with a upper bound on time limit)
-        try {
-            long reconnectWaitTimeout = 10000; // default 10 seconds
-            if (this.ejbClientConfiguration != null && this.ejbClientConfiguration.getReconnectTasksTimeout() > 0) {
-                reconnectWaitTimeout = this.ejbClientConfiguration.getReconnectTasksTimeout();
+
+            // now wait for all tasks to complete (with a upper bound on time limit)
+            try {
+                long reconnectWaitTimeout = 10000; // default 10 seconds
+                if (this.ejbClientConfiguration != null && this.ejbClientConfiguration.getReconnectTasksTimeout() > 0) {
+                    reconnectWaitTimeout = this.ejbClientConfiguration.getReconnectTasksTimeout();
+                }
+                reconnectTasksCompletionNotifierLatch.await(reconnectWaitTimeout, TimeUnit.MILLISECONDS);
+            } catch (InterruptedException e) {
+                // restore the interrupt status
+                Thread.currentThread().interrupt();
+            } finally {
+                // when we reach here, the reconnection should be completed
+
+                // notify the waiting threads
+                try {
+                    reconnectCompletedLock.lock();
+                    if (logger.isTraceEnabled()) {
+                        logger.trace("Reconnection attempt for EJB client context " + this + " complete on thread " + Thread.currentThread().getName());
+                    }
+                    reconnectCompletedCondition.signalAll();
+                } finally {
+                    reconnectCompletedLock.unlock();
+                }
+                // reset the attempting connect flag
+                this.attemptingReconnect.compareAndSet(true, false);
             }
-            reconnectTasksCompletionNotifierLatch.await(reconnectWaitTimeout, TimeUnit.MILLISECONDS);
-        } catch (InterruptedException e) {
-            // ignore
-        } finally {
-            synchronized(this) {
-                this.attemptingReconnect = false;
+        } else {
+            // subsequent threads block until reconnect is completed
+            try {
+                reconnectCompletedLock.lock();
+                if (logger.isTraceEnabled()) {
+                    logger.trace("Waiting for reconnection attempt for EJB client context " + this + " on thread " + Thread.currentThread().getName());
+                }
+                reconnectCompletedCondition.await();
+            } catch (InterruptedException e) {
+                // restore the interrupt status
+                Thread.currentThread().interrupt();
+            } finally {
+                reconnectCompletedLock.unlock();
             }
         }
     }
@@ -1335,8 +1373,8 @@ public final class EJBClientContext extends Attachable implements Closeable {
         @Override
         public void run() {
             try {
-                synchronized(parent) {
-                    if(closed) {
+                synchronized (parent) {
+                    if (closed) {
                         return;
                     }
                 }

--- a/src/test/java/org/jboss/ejb/client/test/reconnect/ReconnectTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/reconnect/ReconnectTestCase.java
@@ -42,6 +42,7 @@ import java.util.Properties;
  * Tests various reconnect scenarios for remote connections registered in a EJB client context
  *
  * @author Jaikiran Pai
+ * @author Richard Achmatowicz
  */
 public class ReconnectTestCase {
 
@@ -192,6 +193,109 @@ public class ReconnectTestCase {
             }
         }
 
+    }
+
+    /**
+     * Tests that a re-connection to a server, which went down after it was initially connected,
+     * is successful under concurrent invocation attempts.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConcurrentReconnectOfBrokenConnection() throws Exception {
+        ContextSelector<EJBClientContext> oldEJBClientContextSelector = null;
+        DummyServer server = null;
+        final String ejbClientConfigResource = "reconnect-jboss-ejb-client.properties";
+        final InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream(ejbClientConfigResource);
+        final int NUM_CONCURRENT_REQUESTS = 3;
+        try {
+            Assert.assertNotNull("Could not find " + ejbClientConfigResource + " through classloader", propertiesStream);
+            // start the server and register the deployment
+            server = this.startServer();
+            server.register("my-app", "my-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+            logger.info("Started server");
+
+            // load the ejb client properties
+            final Properties ejbClientProperties = new Properties();
+            ejbClientProperties.load(propertiesStream);
+
+            // create a configuration out of the properites
+            final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(ejbClientProperties);
+            // create and set the selector
+            oldEJBClientContextSelector = EJBClientContext.setSelector(new ConfigBasedEJBClientContextSelector(ejbClientConfiguration));
+
+            // create a proxy for invocation
+            final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, "my-app", "my-module", EchoBean.class.getSimpleName(), "");
+            final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+            Assert.assertNotNull("Received a null proxy", proxy);
+
+            // try invoking
+            final String message = "Yet another Hello World!!!";
+            // should succeed since the server is up
+            final String firstEcho = proxy.echo(message);
+            Assert.assertEquals("Unexpected echo message returned by the bean", firstEcho, message);
+
+            // now stop the server
+            server.stop();
+            server = null;
+            logger.info("Stopped server");
+
+            // now invoke on the proxy and this should fail since the server is down
+            try {
+                final String echo = proxy.echo(message);
+                Assert.fail("Invocation was expected to fail since the server has been stopped");
+            } catch (IllegalStateException ise) {
+                // expected
+                logger.info("Got the expected failure during invocation on proxy, due to server being down", ise);
+            }
+
+            // now restart server and register the deployment
+            server = this.startServer();
+            server.register("my-app", "my-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+            logger.info("Re-started server");
+
+            // now invoke on the proxy. This should succeed since the reconnect logic should now reconnect to the
+            // restarted server
+            Thread[] threads = new Thread[NUM_CONCURRENT_REQUESTS];
+            for (int i = 0; i < NUM_CONCURRENT_REQUESTS; i++) {
+                final int requestId = i + 1;
+                final String requestIdString = requestId + " / " + NUM_CONCURRENT_REQUESTS;
+                threads[i] = new Thread() {
+                    public void run() {
+                        try {
+                            logger.info("Sending invocation: " + requestIdString);
+                            final String echo = proxy.echo(message);
+                            Assert.assertEquals("Got an unexpected echo", echo, message);
+                            logger.info("Got expected invocation result: " + requestIdString);
+                        } catch (Exception e) {
+                            logger.info("Got exception from request " + requestIdString + ": " + e.getMessage());
+                        }
+                    }
+                };
+                threads[i].start();
+            }
+            // wait for the threads to complete
+            for (int i = 0; i < NUM_CONCURRENT_REQUESTS;i++) {
+                threads[i].join();
+            }
+
+        } finally {
+            if (server != null) {
+                try {
+                    server.stop();
+                    logger.info("Stopped server");
+                } catch (Exception e) {
+                    // ignore
+                    logger.debug("Ignoring exception during server shutdown", e);
+                }
+            }
+            if (propertiesStream != null) {
+                propertiesStream.close();
+            }
+            if (oldEJBClientContextSelector != null) {
+                EJBClientContext.setSelector(oldEJBClientContextSelector);
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds a feature to: :
- allow EJBClientContext.attemptReconnections() to block invocations while a reconnection attempt is ongoing and release the invocations  when the reconnection attempt has completed and EJBReceivers are again available
- a test case which simulates reconnection under concurrent invocation
  
This issue is described in: https://issues.jboss.org/browse/EJBCLIENT-121
