### PR TITLE
EJBCLIENT-126 Use Message Format Patterns

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClient.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClient.java
@@ -224,7 +224,7 @@ public final class EJBClient {
         try {
             return ejbReceiver.openSession(receiverContext, viewType, appName, moduleName, distinctName, beanName);
         } catch (Exception e) {
-            Logs.MAIN.debug("Retrying session creation which failed on node " + ejbReceiver.getNodeName() + " due to:", e);
+            Logs.MAIN.debugf(e, "Retrying session creation which failed on node %s due to:", ejbReceiver.getNodeName());
             // retry ignoring the current failed node
             excludedNodeNames.add(ejbReceiver.getNodeName());
             return createSessionWithPossibleRetries(clientContext, excludedNodeNames, viewType, appName, moduleName, beanName, distinctName);

--- a/src/main/java/org/jboss/ejb/client/EJBClientPropertiesLoader.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientPropertiesLoader.java
@@ -93,16 +93,15 @@ class EJBClientPropertiesLoader {
         // if classpath scan is disabled then skip looking for jboss-ejb-client.properties file in the classpath
         final String skipClasspathScan = SecurityActions.getSystemProperty(EJB_CLIENT_PROPS_SKIP_CLASSLOADER_SCAN_SYS_PROPERTY);
         if (skipClasspathScan != null && Boolean.valueOf(skipClasspathScan.trim())) {
-            logger.debug(EJB_CLIENT_PROPS_SKIP_CLASSLOADER_SCAN_SYS_PROPERTY + " system property is set. " +
-                    "Skipping classloader search for " + EJB_CLIENT_PROPS_FILE_NAME);
+            logger.debugf("%s system property is set. Skipping classloader search for %s", EJB_CLIENT_PROPS_SKIP_CLASSLOADER_SCAN_SYS_PROPERTY, EJB_CLIENT_PROPS_FILE_NAME);
             return null;
         }
         final ClassLoader classLoader = getClientClassLoader();
-        logger.debug("Looking for " + EJB_CLIENT_PROPS_FILE_NAME + " using classloader " + classLoader);
+        logger.debugf("Looking for %s using classloader %s", EJB_CLIENT_PROPS_FILE_NAME, classLoader);
         // find from classloader
         final InputStream clientPropsInputStream = classLoader.getResourceAsStream(EJB_CLIENT_PROPS_FILE_NAME);
         if (clientPropsInputStream != null) {
-            logger.debug("Found " + EJB_CLIENT_PROPS_FILE_NAME + " using classloader " + classLoader);
+            logger.debugf("Found %s using classloader %s", EJB_CLIENT_PROPS_FILE_NAME, classLoader);
             final Properties clientProps = new Properties();
             try {
                 clientProps.load(clientPropsInputStream);

--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -271,7 +271,7 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
             }
             final String failedNodeName = rsfe.getFailedNodeName();
             if (failedNodeName != null) {
-                Logs.MAIN.debug("Retrying invocation " + clientInvocationContext + " which failed on node: " + failedNodeName + " due to:", rsfe);
+                Logs.MAIN.debugf(rsfe, "Retrying invocation %s which failed on node: %s due to:", clientInvocationContext, failedNodeName);
                 // exclude this failed node, during the retry
                 clientInvocationContext.markNodeAsExcluded(failedNodeName);
                 // retry

--- a/src/main/java/org/jboss/ejb/client/PropertiesBasedEJBClientConfiguration.java
+++ b/src/main/java/org/jboss/ejb/client/PropertiesBasedEJBClientConfiguration.java
@@ -239,7 +239,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
     private OptionMap getOptionMapFromProperties(final Properties properties, final String propertyPrefix, final ClassLoader classLoader) {
         final OptionMap.Builder optionMapBuilder = OptionMap.builder().parseAll(properties, propertyPrefix, classLoader);
         final OptionMap optionMap = optionMapBuilder.getMap();
-        logger.debug(propertyPrefix + " has the following options " + optionMap);
+        logger.debugf("%s has the following options %s", propertyPrefix, optionMap);
         return optionMap;
     }
 
@@ -311,7 +311,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
             if (clusterConfiguration == null) {
                 continue;
             }
-            logger.debug("Cluster configuration for cluster " + clusterName + " successfully created");
+            logger.debugf("Cluster configuration for cluster %s successfully created", clusterName);
             // add it to the cluster configuration map
             this.clusterConfigurations.put(clusterName, clusterConfiguration);
         }
@@ -487,7 +487,7 @@ public class PropertiesBasedEJBClientConfiguration implements EJBClientConfigura
             if (connectionConfiguration == null) {
                 continue;
             }
-            logger.debug("Connection " + connectionConfiguration + " successfully created for connection named " + connectionName);
+            logger.debugf("Connection %s successfully created for connection named %s", connectionConfiguration, connectionName);
             // add it to the collection of connection configurations
             this.remotingConnectionConfigurations.add(connectionConfiguration);
         }

--- a/src/main/java/org/jboss/ejb/client/ReceiverInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/ReceiverInterceptor.java
@@ -73,7 +73,7 @@ public final class ReceiverInterceptor implements EJBClientInterceptor {
                     final EJBReceiver nodeReceiver;
                     // ignore the weak affinity if the node has been marked as excluded for this invocation context
                     if (excludedNodes.contains(nodeName)) {
-                        logger.debug("Ignoring weak affinity on node " + nodeName + " since that node has been marked as excluded for invocation context " + invocationContext);
+                        logger.debugf("Ignoring weak affinity on node %s since that node has been marked as excluded for invocation context %s", nodeName, invocationContext);
                         nodeReceiver = null;
                     } else {
                         nodeReceiver = clientContext.getNodeEJBReceiver(nodeName);
@@ -93,7 +93,7 @@ public final class ReceiverInterceptor implements EJBClientInterceptor {
                     final EJBReceiver nodeReceiver;
                     // ignore the weak affinity if the node has been marked as excluded for this invocation context
                     if (excludedNodes.contains(nodeName)) {
-                        logger.debug("Ignoring weak affinity on node " + nodeName + " since that node has been marked as excluded for invocation context " + invocationContext);
+                        logger.debugf("Ignoring weak affinity on node %s since that node has been marked as excluded for invocation context %s", nodeName, invocationContext);
                         nodeReceiver = null;
                     } else {
                         nodeReceiver = clientContext.getNodeEJBReceiver(nodeName);

--- a/src/main/java/org/jboss/ejb/client/RecoveryOnlyEJBXAResource.java
+++ b/src/main/java/org/jboss/ejb/client/RecoveryOnlyEJBXAResource.java
@@ -51,20 +51,20 @@ class RecoveryOnlyEJBXAResource implements XAResource {
     public void commit(Xid xid, boolean onePhase) throws XAException {
         final XidTransactionID transactionID = new XidTransactionID(xid);
         final EJBReceiver receiver = receiverContext.getReceiver();
-        Logs.TXN.debug("Sending commit request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery. One phase? " + onePhase);
+        Logs.TXN.debugf("Sending commit request for Xid %s to EJB receiver with node name %s during recovery. One phase? %s", xid, receiver.getNodeName(), onePhase);
         receiver.sendCommit(receiverContext, transactionID, onePhase);
     }
 
     @Override
     public void end(Xid xid, int i) throws XAException {
-        Logs.TXN.debug("Ignoring end request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+        Logs.TXN.debugf("Ignoring end request on XAResource %s since this XAResource is only meant for transaction recovery", this);
     }
 
     @Override
     public void forget(Xid xid) throws XAException {
         final XidTransactionID transactionID = new XidTransactionID(xid);
         final EJBReceiver receiver = receiverContext.getReceiver();
-        Logs.TXN.debug("Sending forget request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+        Logs.TXN.debugf("Sending forget request for Xid %s to EJB receiver with node name %s during recovery", xid, receiver.getNodeName());
         receiver.sendForget(receiverContext, transactionID);
     }
 
@@ -94,15 +94,14 @@ class RecoveryOnlyEJBXAResource implements XAResource {
 
     @Override
     public int prepare(Xid xid) throws XAException {
-        Logs.TXN.debug("Prepare wasn't supposed to be called on " + this + " since this XAResource is only meant for transaction recovery. " +
-                "Ignoring the prepare request for xid " + xid);
+        Logs.TXN.debugf("Prepare wasn't supposed to be called on %s since this XAResource is only meant for transaction recovery. Ignoring the prepare request for xid %s", this, xid);
         return XA_OK;
     }
 
     @Override
     public Xid[] recover(final int flags) throws XAException {
         final EJBReceiver receiver = receiverContext.getReceiver();
-        Logs.TXN.debug("Send recover request for transaction origin node identifier " + transactionOriginNodeIdentifier + " to EJB receiver with node name " + receiver.getNodeName());
+        Logs.TXN.debugf("Send recover request for transaction origin node identifier %s to EJB receiver with node name %s", transactionOriginNodeIdentifier, receiver.getNodeName());
         return receiver.sendRecover(receiverContext, transactionOriginNodeIdentifier, flags);
     }
 
@@ -110,7 +109,7 @@ class RecoveryOnlyEJBXAResource implements XAResource {
     public void rollback(Xid xid) throws XAException {
         final XidTransactionID transactionID = new XidTransactionID(xid);
         final EJBReceiver receiver = receiverContext.getReceiver();
-        Logs.TXN.debug("Sending rollback request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+        Logs.TXN.debugf("Sending rollback request for Xid %s to EJB receiver with node name %s during recovery", xid, receiver.getNodeName());
         receiver.sendRollback(receiverContext, transactionID);
     }
 
@@ -121,7 +120,7 @@ class RecoveryOnlyEJBXAResource implements XAResource {
 
     @Override
     public void start(Xid xid, int i) throws XAException {
-        Logs.TXN.debug("Ignoring start request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+        Logs.TXN.debugf("Ignoring start request on XAResource %s since this XAResource is only meant for transaction recovery", this);
     }
 
     @Override

--- a/src/main/java/org/jboss/ejb/client/RecoveryOnlySerializedEJBXAResource.java
+++ b/src/main/java/org/jboss/ejb/client/RecoveryOnlySerializedEJBXAResource.java
@@ -49,13 +49,13 @@ class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
     public void commit(Xid xid, boolean onePhase) throws XAException {
         final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
         if (receiverContexts.isEmpty()) {
-            Logs.TXN.debug("No EJB receiver contexts available for committing EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            Logs.TXN.debugf("No EJB receiver contexts available for committing EJB XA resource for Xid %s during transaction recovery. Returning XAException.XA_RETRY", xid);
             throw new XAException(XAException.XA_RETRY);
         }
         final XidTransactionID transactionID = new XidTransactionID(xid);
         for (final EJBReceiverContext receiverContext : receiverContexts) {
             final EJBReceiver receiver = receiverContext.getReceiver();
-            Logs.TXN.debug(this + " sending commit request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery. One phase? " + onePhase);
+            Logs.TXN.debugf("%s sending commit request for Xid %s to EJB receiver with node name %s during recovery. One phase? %s", this, xid, receiver.getNodeName(), onePhase);
             receiver.sendCommit(receiverContext, transactionID, onePhase);
         }
     }
@@ -64,14 +64,14 @@ class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
     public void rollback(Xid xid) throws XAException {
         final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
         if (receiverContexts.isEmpty()) {
-            Logs.TXN.debug("No EJB receiver contexts available for rolling back EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            Logs.TXN.debugf("No EJB receiver contexts available for rolling back EJB XA resource for Xid %s during transaction recovery. Returning XAException.XA_RETRY", xid);
             throw new XAException(XAException.XA_RETRY);
         }
 
         final XidTransactionID transactionID = new XidTransactionID(xid);
         for (final EJBReceiverContext receiverContext : receiverContexts) {
             final EJBReceiver receiver = receiverContext.getReceiver();
-            Logs.TXN.debug(this + " sending rollback request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+            Logs.TXN.debugf("%s sending rollback request for Xid %s to EJB receiver with node name %s during recovery", this, xid, receiver.getNodeName());
             receiver.sendRollback(receiverContext, transactionID);
         }
     }
@@ -80,20 +80,20 @@ class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
     public void forget(Xid xid) throws XAException {
         final List<EJBReceiverContext> receiverContexts = ReceiverRegistrationListener.INSTANCE.getRelevantReceiverContexts(this.ejbReceiverNodeName);
         if (receiverContexts.isEmpty()) {
-            Logs.TXN.debug("No EJB receiver contexts available for forgetting EJB XA resource for Xid " + xid + " during transaction recovery. Returning XAException.XA_RETRY");
+            Logs.TXN.debugf("No EJB receiver contexts available for forgetting EJB XA resource for Xid %s during transaction recovery. Returning XAException.XA_RETRY", xid);
             throw new XAException(XAException.XA_RETRY);
         }
         final XidTransactionID transactionID = new XidTransactionID(xid);
         for (final EJBReceiverContext receiverContext : receiverContexts) {
             final EJBReceiver receiver = receiverContext.getReceiver();
-            Logs.TXN.debug(this + " sending forget request for Xid " + xid + " to EJB receiver with node name " + receiver.getNodeName() + " during recovery");
+            Logs.TXN.debugf("%s sending forget request for Xid %s to EJB receiver with node name %s during recovery", this, xid, receiver.getNodeName());
             receiver.sendForget(receiverContext, transactionID);
         }
     }
 
     @Override
     public void end(Xid xid, int i) throws XAException {
-        Logs.TXN.debug("Ignoring end request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+        Logs.TXN.debugf("Ignoring end request on XAResource %s since this XAResource is only meant for transaction recovery", this);
     }
 
     @Override
@@ -108,8 +108,10 @@ class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
 
     @Override
     public int prepare(Xid xid) throws XAException {
-        Logs.TXN.debug("Prepare wasn't supposed to be called on " + this + " since this XAResource is only meant for transaction recovery. " +
-                "Ignoring the prepare request for xid " + xid);
+        if (Logs.TXN.isDebugEnabled()) {
+            Logs.TXN.debug("Prepare wasn't supposed to be called on " + this + " since this XAResource is only meant for transaction recovery. "
+                    + "Ignoring the prepare request for xid " + xid);
+        }
         return XA_OK;
     }
 
@@ -126,7 +128,7 @@ class RecoveryOnlySerializedEJBXAResource implements XAResource, Serializable {
 
     @Override
     public void start(Xid xid, int i) throws XAException {
-        Logs.TXN.debug("Ignoring start request on XAResource " + this + " since this XAResource is only meant for transaction recovery");
+        Logs.TXN.debugf("Ignoring start request on XAResource %s since this XAResource is only meant for transaction recovery", this);
     }
 
 

--- a/src/main/java/org/jboss/ejb/client/naming/ejb/EjbNamingContext.java
+++ b/src/main/java/org/jboss/ejb/client/naming/ejb/EjbNamingContext.java
@@ -413,8 +413,10 @@ class EjbNamingContext implements Context {
             // unregister the scoped EJB client context
             final ContextSelector<EJBClientContext> currentSelector = EJBClientContext.getSelector();
             if (!(currentSelector instanceof IdentityEJBClientContextSelector)) {
-                log.debug("Cannot unregister a scoped EJB client context for JNDI naming context " + this + " since the current " +
-                        "EJB client context selector can't handle scoped contexts");
+                if (log.isDebugEnabled()) {
+                    log.debug("Cannot unregister a scoped EJB client context for JNDI naming context " + this
+                            + " since the current " + "EJB client context selector can't handle scoped contexts");
+                }
                 return;
             }
             final EJBClientContext previouslyRegisteredContext = ((IdentityEJBClientContextSelector) currentSelector).unRegisterContext(this.ejbClientContextIdentifier);

--- a/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
@@ -115,7 +115,7 @@ class ChannelAssociation {
         this.channel.addCloseHandler(new CloseHandler<Channel>() {
             @Override
             public void handleClose(Channel closed, IOException exception) {
-                logger.debug("Closing channel " + closed, exception);
+                logger.debugf(exception, "Closing channel %s", closed);
                 // notify about the broken channel and do the necessary cleanups
                 if (exception != null) {
                     ChannelAssociation.this.notifyBrokenChannel(exception);
@@ -232,7 +232,7 @@ class ChannelAssociation {
     void handleAsyncMethodNotification(final short invocationId) {
         final EJBReceiverInvocationContext receiverInvocationContext = this.waitingMethodInvocations.get(invocationId);
         if (receiverInvocationContext == null) {
-            logger.debug("No waiting context found for async method invocation with id " + invocationId);
+            logger.debugf("No waiting context found for async method invocation with id %s", invocationId);
             return;
         }
         receiverInvocationContext.proceedAsynchronously();
@@ -358,7 +358,9 @@ class ChannelAssociation {
         // get the protocol message handler for the header
         final ProtocolMessageHandler messageHandler = getProtocolMessageHandler((byte) header);
         if (messageHandler == null) {
-            logger.debug("Unsupported message received with header 0x" + Integer.toHexString(header));
+            if (logger.isDebugEnabled()) {
+                logger.debug("Unsupported message received with header 0x" + Integer.toHexString(header));
+            }
             return;
         }
         // let the protocol handler process the stream
@@ -421,7 +423,10 @@ class ChannelAssociation {
             // register a re-connect handler (if available) to the EJB client context
             if (this.reconnectHandler != null) {
                 final EJBClientContext ejbClientContext = this.ejbReceiverContext.getClientContext();
-                logger.debug("Registering a re-connect handler " + this.reconnectHandler + " for broken channel " + this.channel + " in EJB client context " + ejbClientContext);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Registering a re-connect handler " + this.reconnectHandler + " for broken channel "
+                            + this.channel + " in EJB client context " + ejbClientContext);
+                }
                 ejbClientContext.registerReconnectHandler(this.reconnectHandler);
             }
         }

--- a/src/main/java/org/jboss/ejb/client/remoting/ClusterNode.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ClusterNode.java
@@ -132,10 +132,10 @@ final class ClusterNode {
             final InetAddress sourceNetworkAddress = clientMapping.getSourceNetworkAddress();
             final int netMask = clientMapping.getSourceNetworkMaskBits();
             for (final InetAddress address : ALL_INET_ADDRESSES) {
-                logger.debug("Checking for a match of client address " + address + " with client mapping " + clientMapping);
+                logger.debugf("Checking for a match of client address %s with client mapping %s", address, clientMapping);
                 final boolean match = NetworkUtil.belongsToNetwork(address, sourceNetworkAddress, netMask & 0xff);
                 if (match) {
-                    logger.debug("Client mapping " + clientMapping + " matches client address " + address);
+                    logger.debugf("Client mapping %s matches client address %s", clientMapping, address);
                     this.resolvedDestination = new ResolvedDestination(clientMapping.getDestinationAddress(), clientMapping.getDestinationPort());
                     return;
                 }

--- a/src/main/java/org/jboss/ejb/client/remoting/ClusterNodeRemovalHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ClusterNodeRemovalHandler.java
@@ -85,7 +85,10 @@ class ClusterNodeRemovalHandler extends ProtocolMessageHandler {
         for (final Map.Entry<String, Collection<String>> entry : removedNodesPerCluster.entrySet()) {
             final String clusterName = entry.getKey();
             final Collection<String> removedNodes = entry.getValue();
-            logger.debug("Received a cluster node(s) removal message, for cluster named " + clusterName + " with " + removedNodes.size() + " removed nodes " + Arrays.toString(removedNodes.toArray()));
+            if (logger.isDebugEnabled()) {
+                logger.debug("Received a cluster node(s) removal message, for cluster named " + clusterName + " with "
+                        + removedNodes.size() + " removed nodes " + Arrays.toString(removedNodes.toArray()));
+            }
             // get a cluster context for the cluster name
             final ClusterContext clusterContext = clientContext.getClusterContext(clusterName);
             // if there's no cluster context yet (which can happen if the cluster topology hasn't yet been received)

--- a/src/main/java/org/jboss/ejb/client/remoting/ClusterRemovalMessageHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ClusterRemovalMessageHandler.java
@@ -70,7 +70,10 @@ class ClusterRemovalMessageHandler extends ProtocolMessageHandler {
         }
         // let the client context know that about the removed clusters
         final EJBClientContext clientContext = this.ejbReceiverContext.getClientContext();
-        logger.debug("Received a cluster removal message for " + removedClusters.size() + " clusters " + Arrays.toString(removedClusters.toArray()));
+        if (logger.isDebugEnabled()) {
+            logger.debug("Received a cluster removal message for " + removedClusters.size() + " clusters "
+                    + Arrays.toString(removedClusters.toArray()));
+        }
         for (final String clusterName : removedClusters) {
             // remove the cluster from the client context
             clientContext.removeCluster(clusterName);

--- a/src/main/java/org/jboss/ejb/client/remoting/ClusterTopologyMessageHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ClusterTopologyMessageHandler.java
@@ -122,7 +122,10 @@ class ClusterTopologyMessageHandler extends ProtocolMessageHandler {
         for (final Map.Entry<String, Collection<ClusterNode>> entry : clusterNodes.entrySet()) {
             final String clusterName = entry.getKey();
             final Collection<ClusterNode> nodes = entry.getValue();
-            logger.debug("Received a cluster node(s) addition message, for cluster named " + clusterName + " with " + nodes.size() + " nodes " + Arrays.toString(nodes.toArray()));
+            if (logger.isDebugEnabled()) {
+                logger.debug("Received a cluster node(s) addition message, for cluster named " + clusterName + " with "
+                        + nodes.size() + " nodes " + Arrays.toString(nodes.toArray()));
+            }
             // create a cluster context and add the nodes to it
             final ClusterContext clusterContext = clientContext.getOrCreateClusterContext(clusterName);
             // if this is a complete topology message, then we'll first remove any existing nodes from the cluster context

--- a/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ConfigBasedEJBClientContextSelector.java
@@ -146,7 +146,10 @@ public class ConfigBasedEJBClientContextSelector implements IdentityEJBClientCon
             // can attempt the connection whenever it's required to do so.
             if (!connectionConfiguration.isConnectEagerly()) {
                 this.ejbClientContext.registerReconnectHandler(reconnectHandler);
-                logger.debug("Connection to host: " + host + " and port: " + port + ", in EJB client context: " + this.ejbClientContext + ", is configured to be attempted lazily. Skipping connection creation for now");
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Connection to host: " + host + " and port: " + port + ", in EJB client context: "
+                            + this.ejbClientContext + ", is configured to be attempted lazily. Skipping connection creation for now");
+                }
 
             } else {
                 // attempt to connect eagerly
@@ -164,11 +167,11 @@ public class ConfigBasedEJBClientContextSelector implements IdentityEJBClientCon
                     logger.warn("Could not register a EJB receiver for connection to " + host + ":" + port, e);
                     // add a reconnect handler for this connection
                     this.ejbClientContext.registerReconnectHandler(reconnectHandler);
-                    logger.debug("Registered a reconnect handler in EJB client context " + this.ejbClientContext + " for remote://" + host + ":" + port);
+                    logger.debugf("Registered a reconnect handler in EJB client context %s for remote://%s:%d", this.ejbClientContext,  host, port);
                 }
             }
         }
-        logger.debug("Registered " + successfulEJBReceiverRegistrations + " remoting EJB receivers for EJB client context " + this.ejbClientContext);
+        logger.debugf("Registered %s remoting EJB receivers for EJB client context %s", successfulEJBReceiverRegistrations, this.ejbClientContext);
     }
 
     @Override

--- a/src/main/java/org/jboss/ejb/client/remoting/ConnectionPool.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ConnectionPool.java
@@ -175,7 +175,7 @@ class ConnectionPool {
         try {
             closable.close();
         } catch (Throwable t) {
-            logger.debug("Failed to close " + closable, t);
+            logger.debugf(t, "Failed to close %s", closable);
         }
     }
 

--- a/src/main/java/org/jboss/ejb/client/remoting/MaxAttemptsReconnectHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/MaxAttemptsReconnectHandler.java
@@ -63,11 +63,11 @@ abstract class MaxAttemptsReconnectHandler implements ReconnectHandler {
         reconnectAttempts++;
         try {
             final Connection connection = remotingConnectionManager.getConnection(endpoint, protocol, host, port, connectionConfiguration);
-            logger.debug("Successfully reconnected on attempt#" + reconnectAttempts + " to connection " + connection);
+            logger.debugf("Successfully reconnected on attempt#%d to connection %s", reconnectAttempts, connection);
             return connection;
 
         } catch (Exception e) {
-            logger.debug("Re-connect attempt# " + reconnectAttempts + " failed for " + host + ":" + port, e);
+            logger.debugf(e, "Re-connect attempt# %d failed for %s:%d", reconnectAttempts, host, port);
             return null;
         }
 

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingCleanupHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingCleanupHandler.java
@@ -77,10 +77,10 @@ class RemotingCleanupHandler implements EJBClientContextListener {
 
     private void safeClose(Closeable closable) {
         try {
-            logger.debug("Closing " + closable);
+            logger.debugf("Closing %s", closable);
             closable.close();
         } catch (Throwable e) {
-            logger.debug("Exception closing " + closable, e);
+            logger.debugf(e, "Exception closing %s", closable);
         }
     }
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -172,7 +172,7 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
         final IoFuture<Channel> futureChannel = connection.openChannel(EJB_CHANNEL_NAME, this.channelCreationOptions);
         futureChannel.addNotifier(new IoFuture.HandlingNotifier<Channel, EJBReceiverContext>() {
             public void handleCancelled(final EJBReceiverContext context) {
-                logger.debug("Channel open requested cancelled for context " + context);
+                logger.debugf("Channel open requested cancelled for context %s", context);
                 context.close();
             }
 
@@ -184,11 +184,11 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
             public void handleDone(final Channel channel, final EJBReceiverContext context) {
                 channel.addCloseHandler(new CloseHandler<Channel>() {
                     public void handleClose(final Channel closed, final IOException exception) {
-                        logger.debug("Closing channel" + closed, exception);
+                        logger.debugf(exception, "Closing channel%s", closed);
                         context.close();
                     }
                 });
-                logger.debug("Channel " + channel + " opened for context " + context + " Waiting for version handshake message from server");
+                logger.debugf("Channel %s opened for context %s Waiting for version handshake message from server", channel, context);
                 // receive version message from server
                 channel.receiveMessage(versionReceiver);
             }
@@ -225,7 +225,7 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
                     //only add the reconnect handler if the version handshake did not fail due to an incompatibility
                     // (latch is not being counted down on failure)
                     if (!versionReceiver.failedCompatibility()) {
-                        logger.debug("Adding reconnect handler to client context " + context.getClientContext());
+                        logger.debugf("Adding reconnect handler to client context %s", context.getClientContext());
                         context.getClientContext().registerReconnectHandler(this.reconnectHandler);
                     }
                 }
@@ -247,7 +247,7 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
                     Logs.REMOTING.initialModuleAvailabilityReportNotReceived(this);
                 }
             } catch (InterruptedException e) {
-                logger.debug("Caught InterruptedException while waiting for initial module availability report for " + this, e);
+                logger.debugf(e, "Caught InterruptedException while waiting for initial module availability report for %s", this);
             }
         }
     }
@@ -743,9 +743,9 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
     }
 
     void modulesAvailable(final EJBReceiverContext receiverContext, final ModuleAvailabilityMessageHandler.EJBModuleIdentifier[] ejbModules) {
-        logger.debug("Received module availability report for " + ejbModules.length + " modules");
+        logger.debugf("Received module availability report for %d modules", ejbModules.length);
         for (final ModuleAvailabilityMessageHandler.EJBModuleIdentifier moduleIdentifier : ejbModules) {
-            logger.debug("Registering module " + moduleIdentifier + " availability for receiver context " + receiverContext);
+            logger.debugf("Registering module %s availability for receiver context %s", moduleIdentifier, receiverContext);
             this.registerModule(moduleIdentifier.appName, moduleIdentifier.moduleName, moduleIdentifier.distinctName);
         }
         // notify of module availability report if anyone's waiting on the latch
@@ -759,9 +759,9 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
     }
 
     void modulesUnavailable(final EJBReceiverContext receiverContext, final ModuleAvailabilityMessageHandler.EJBModuleIdentifier[] ejbModules) {
-        logger.debug("Received module un-availability report for " + ejbModules.length + " modules");
+        logger.debugf("Received module un-availability report for %d modules", ejbModules.length);
         for (final ModuleAvailabilityMessageHandler.EJBModuleIdentifier moduleIdentifier : ejbModules) {
-            logger.debug("Un-registering module " + moduleIdentifier + " from receiver context " + receiverContext);
+            logger.debugf("Un-registering module %s from receiver context %s", moduleIdentifier, receiverContext);
             this.deregisterModule(moduleIdentifier.appName, moduleIdentifier.moduleName, moduleIdentifier.distinctName);
         }
     }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionManager.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionManager.java
@@ -64,7 +64,7 @@ class RemotingConnectionManager {
                 try {
                     connection.close();
                 } catch (Throwable t) {
-                    logger.debug("Failed to close " + connection, t);
+                    logger.debugf(t, "Failed to close %s", connection);
                 }
             }
         }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingEndpointManager.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingEndpointManager.java
@@ -62,7 +62,7 @@ class RemotingEndpointManager {
                 try {
                     endpoint.close();
                 } catch (Throwable t) {
-                    logger.debug("Failed to close " + endpoint, t);
+                    logger.debugf(t, "Failed to close %s", endpoint);
                 }
             }
         }


### PR DESCRIPTION
Most of the JBoss code uses message format patterns for debug logging
in order to avoid unnecessary allocations in normal operation. The
JBoss EJB client seems to be one of the few places where this is not
yet the case and debug messages are always created even if the debug
logging is disabled.

 * use `#debugf` for debug logging
 * use `#isDebugEnabled` for debug statements too complex for `#debugf`

Issue: EJBCLIENT-126
https://issues.jboss.org/browse/EJBCLIENT-126