### PR TITLE
[EJBCLIENT-130] Cleanup stale waiting invocationID upon retry of invocation attempt which failed with NoSuchEJBException

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
@@ -181,6 +181,25 @@ class ChannelAssociation {
     }
 
     /**
+     * De-enroll a {@link EJBReceiverInvocationContext} from receiving (an inherently asynchronous) response for a
+     * invocation corresponding to the passed <code>invocationId</code>.
+     * This action is required when an invocation is retried on another node as a result of a NoSuchEJBException
+     * and effectively cleans up the stale invocationID and EJBClientReceiverContext of the previous attempt.
+     * .
+     * @param invocationId
+     */
+    void cleanupStaleResponse(final short invocationId) {
+        if (this.waitingMethodInvocations.containsKey(invocationId)) {
+            final EJBReceiverInvocationContext ejbReceiverInvocationContext = this.waitingMethodInvocations.remove(invocationId);
+            if (ejbReceiverInvocationContext != null) {
+                // we no longer need to keep track of the invocation id that was used for
+                // this EJB receiver invocation context, so remove it
+                this.invocationIdsPerReceiverInvocationCtx.remove(ejbReceiverInvocationContext);
+            }
+        }
+    }
+
+    /**
      * Returns a {@link Future} {@link EJBReceiverInvocationContext.ResultProducer result producer} for the
      * passed <code>invocationId</code>. This method does <b>not</b> block. The caller can use the returned
      * {@link Future} to {@link java.util.concurrent.Future#get() wait} for a {@link org.jboss.ejb.client.EJBReceiverInvocationContext.ResultProducer}

--- a/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
@@ -75,6 +75,9 @@ class NoSuchEJBExceptionResponseHandler extends ProtocolMessageHandler {
         // retry the invocation on a different node
         try {
             logger.info("Retrying invocation which failed on node " + receiverInvocationContext.getNodeName() + " with exception:", noSuchEJBException);
+            // EJBCLIENT-130: remove any stale invocationID associated with the failed invocation from
+            // the ChannelAssociation map of waiting method invocations
+            this.channelAssociation.cleanupStaleResponse(invocationId);
             receiverInvocationContext.retryInvocation(true);
         } catch (Exception e) {
             // retry failed, let the waiting client know of this failure


### PR DESCRIPTION
For details: see https://issues.jboss.org/browse/EJBCLIENT-130