### PR TITLE
[EJBCLIENT-131] : If large parameters are given to an EJB method invocation the client show a EJBCLIENT000032 Exception - the OutOfMemoryError is swallowed

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -28,6 +28,7 @@ import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 import java.rmi.RemoteException;
+import java.rmi.UnmarshalException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -264,6 +265,8 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
                     throw (RuntimeException) rsfe.getCause();
                 }else if(rsfe.getCause() instanceof NotSerializableException) {
                     throw (NotSerializableException)rsfe.getCause();
+                }else if (rsfe.getCause() instanceof UnmarshalException) {
+                    throw (UnmarshalException) rsfe.getCause();
                 }
             }
             final String failedNodeName = rsfe.getFailedNodeName();

--- a/src/main/java/org/jboss/ejb/client/Logs.java
+++ b/src/main/java/org/jboss/ejb/client/Logs.java
@@ -38,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
+import java.rmi.UnmarshalException;
 
 import static org.jboss.logging.Logger.Level.INFO;
 import static org.jboss.logging.Logger.Level.WARN;
@@ -298,4 +299,7 @@ public interface Logs extends BasicLogger {
     @LogMessage(level = INFO)
     @Message(id = 406, value = "Unexpected exception when discarding invocation result")
     void exceptionOnDiscardResult(@Cause IOException exception);
+
+    @Message(id = 407, value = "Issue regarding unmarshalling of EJB parameters (possible Out of Memory issue).")
+    UnmarshalException ejbClientInvocationParamsException(@Cause Exception e);
 }

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -52,6 +52,7 @@ import org.jboss.ejb.client.EJBReceiverContext;
 import org.jboss.ejb.client.EJBReceiverInvocationContext;
 import org.jboss.ejb.client.Logs;
 import org.jboss.ejb.client.RequestSendFailedException;
+import java.rmi.UnmarshalException;
 import org.jboss.ejb.client.StatefulEJBLocator;
 import org.jboss.ejb.client.TransactionID;
 import org.jboss.ejb.client.annotation.CompressionHint;
@@ -99,6 +100,8 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
     private final OptionMap channelCreationOptions;
 
     private final String remotingProtocol;
+
+    private static final Logs log = Logs.MAIN;
 
     /**
      * Construct a new instance.
@@ -326,7 +329,11 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
                     // and the parameters
                     if (methodParams != null && methodParams.length > 0) {
                         for (final Object methodParam : methodParams) {
-                            marshaller.writeObject(methodParam);
+                            try {
+                                marshaller.writeObject(methodParam);
+                            } catch (IOException e) {
+                                throw log.ejbClientInvocationParamsException(e);
+                            }
                         }
                     }
                     // write out the attachments


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-131
Caused by : https://issues.jboss.org/browse/WFLY-3266