### PR TITLE
[EJBCLIENT-119] disassociate EJBReceiver when unregistering from EJBClie...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -427,6 +427,10 @@ public final class EJBClientContext extends Attachable implements Closeable {
             final ReceiverAssociation association = this.ejbReceiverAssociations.remove(receiver);
             if (association != null) {
                 final EJBReceiverContext receiverContext = association.context;
+
+                // EJBCLIENT-119 - disassociate to ensure clean up & not leaking classloaders
+                receiver.disassociate(receiverContext);
+
                 final EJBReceiverContextCloseHandler receiverContextCloseHandler = this.receiverContextCloseHandlers.remove(receiverContext);
                 if (receiverContextCloseHandler != null) {
                     receiverContextCloseHandler.receiverContextClosed(receiverContext);
@@ -1199,6 +1203,15 @@ public final class EJBClientContext extends Attachable implements Closeable {
         // *isn't* the responsibility of the EJB client context. We'll just let our EJBClientContextListeners
         // (if any) know about the context being closed and let them handle closing the receivers if they want to
         this.closed = true;
+
+        // WFLY-4016 - call unregisterEJBReceiver so that listener.receiverUnRegistered(...) is called to prevent memory leak
+        EJBReceiver[] ejbReceivers;
+        synchronized (this.ejbReceiverAssociations) {
+            ejbReceivers = this.ejbReceiverAssociations.keySet().toArray(new EJBReceiver[this.ejbReceiverAssociations.size()]);
+        }
+        for(final EJBReceiver receiver : ejbReceivers) {
+            unregisterEJBReceiver(receiver);
+        }
 
         // use a new array to iterate on to avoid ConcurrentModificationException EJBCLIENT-92
         EJBClientContextListener[] listeners;

--- a/src/main/java/org/jboss/ejb/client/EJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/EJBReceiver.java
@@ -85,6 +85,13 @@ public abstract class EJBReceiver extends Attachable {
     protected abstract void associate(EJBReceiverContext context);
 
     /**
+     * Remove an association of this EJB receiver with the EJB client context.
+     *
+     * @param context the receiver context
+     */
+    protected abstract void disassociate(EJBReceiverContext context);
+
+    /**
      * Process the invocation.  Implementations of this method should always execute the operation asynchronously.  The
      * operation result should be passed in to the receiver invocation context.  To ensure ideal GC behavior, the
      * receiver should discard any reference to the invocation context(s) once the result producer has been set.

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -67,6 +67,7 @@ import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoFuture;
+import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 
 /**
@@ -249,6 +250,28 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
             } catch (InterruptedException e) {
                 logger.debug("Caught InterruptedException while waiting for initial module availability report for " + this, e);
             }
+        }
+    }
+
+    @Override
+    public void disassociate(final EJBReceiverContext context) {
+        ChannelAssociation channelAssociation = null;
+        synchronized (this.channelAssociations) {
+            channelAssociation = this.channelAssociations.remove(context);
+        }
+
+        // close the channel that is associated
+        if(channelAssociation != null) {
+            try {
+                channelAssociation.getChannel().close();
+            } catch(IOException e) {
+                logger.warn("Caught IOException when trying to close channel: " + channelAssociation.getChannel(), e);
+            }
+        }
+
+        // unregister reconnect handler
+        if (this.reconnectHandler != null) {
+            context.getClientContext().unregisterReconnectHandler(this.reconnectHandler);
         }
     }
 

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyEJBReceiver.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyEJBReceiver.java
@@ -45,6 +45,11 @@ public class DummyEJBReceiver extends EJBReceiver {
     }
 
     @Override
+    protected void disassociate(EJBReceiverContext context) {
+    }
+
+
+    @Override
     protected void processInvocation(EJBClientInvocationContext mapEJBClientInvocationContext, EJBReceiverInvocationContext receiverContext) throws Exception {
     }
 


### PR DESCRIPTION
...ntContext to prevent memory and channel leaks
https://issues.jboss.org/browse/EJBCLIENT-119
There are test case failures, but they occurred before the PR.