### PR TITLE
[EJBCLIENT-119] Attempt 2: disassociate EJBReceiver when unregistering f...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/EJBReceiver.java
@@ -85,6 +85,13 @@ public abstract class EJBReceiver extends Attachable {
     protected abstract void associate(EJBReceiverContext context);
 
     /**
+     * Remove an association of this EJB receiver with the EJB client context.
+     *
+     * @param context the receiver context
+     */
+    protected abstract void disassociate(EJBReceiverContext context);
+
+    /**
      * Process the invocation.  Implementations of this method should always execute the operation asynchronously.  The
      * operation result should be passed in to the receiver invocation context.  To ensure ideal GC behavior, the
      * receiver should discard any reference to the invocation context(s) once the result producer has been set.

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -58,6 +58,7 @@ import org.jboss.remoting3.CloseHandler;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.MessageOutputStream;
 import org.xnio.IoFuture;
+import org.xnio.IoUtils;
 import org.xnio.OptionMap;
 
 /**
@@ -205,6 +206,23 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
                 }
             } catch (InterruptedException e) {
                 logger.debug("Caught InterruptedException while waiting for initial module availability report for " + this, e);
+            }
+        }
+    }
+
+    @Override
+    public void disassociate(final EJBReceiverContext context) {
+        ChannelAssociation channelAssociation = null;
+        synchronized (this.channelAssociations) {
+            channelAssociation = this.channelAssociations.remove(context);
+        }
+
+        // close the channel that is associated
+        if(channelAssociation != null) {
+            try {
+                channelAssociation.getChannel().close();
+            } catch(IOException e) {
+                logger.warn("Caught IOException when trying to close channel: " + channelAssociation.getChannel(), e);
             }
         }
     }

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyEJBReceiver.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyEJBReceiver.java
@@ -45,6 +45,11 @@ public class DummyEJBReceiver extends EJBReceiver {
     }
 
     @Override
+    protected void disassociate(EJBReceiverContext context) {
+    }
+
+
+    @Override
     protected void processInvocation(EJBClientInvocationContext mapEJBClientInvocationContext, EJBReceiverInvocationContext receiverContext) throws Exception {
     }
 


### PR DESCRIPTION
...rom EJBClientContext to prevent memory and channel leaks
https://issues.jboss.org/browse/EJBCLIENT-119
