### PR TITLE
[EJBCLIENT-119] Attempt 2: disassociate EJBReceiver when unregistering f...

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionEJBReceiver.java
@@ -265,11 +265,6 @@ public final class RemotingConnectionEJBReceiver extends EJBReceiver {
                 logger.warn("Caught IOException when trying to close channel: " + channelAssociation.getChannel(), e);
             }
         }
-
-        // unregister reconnect handler
-        if (this.reconnectHandler != null) {
-            context.getClientContext().unregisterReconnectHandler(this.reconnectHandler);
-        }
     }
 
     @Override


### PR DESCRIPTION
...rom EJBClientContext to prevent memory and channel leaks
https://issues.jboss.org/browse/EJBCLIENT-119