### PR TITLE
[EJBCLIENT-94] EJB clients do not attempt to reconnect to any receivers until all receivers have failed (TEST CASES)

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -1220,7 +1220,14 @@ public final class EJBClientContext extends Attachable implements Closeable {
         // *isn't* the responsibility of the EJB client context. We'll just let our EJBClientContextListeners
         // (if any) know about the context being closed and let them handle closing the receivers if they want to
         this.closed = true;
-
+        // tasks reconnection cleanup. control when these tasks are cancelled.
+        synchronized (reconnectTasks) {
+            Iterator<ScheduledFuture<?>> iterator = reconnectTasks.values().iterator();
+            while(iterator.hasNext()) {
+                iterator.next().cancel(false);
+                iterator.remove();
+            }
+        }
         // use a new array to iterate on to avoid ConcurrentModificationException EJBCLIENT-92
         EJBClientContextListener[] listeners;
         synchronized (this.ejbClientContextListeners) {

--- a/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
+++ b/src/test/java/org/jboss/ejb/client/test/common/DummyServer.java
@@ -619,4 +619,8 @@ public class DummyServer {
             return result;
         }
     }
+
+    public int getNumberChannelsOpened() {
+        return openChannels.size();	
+    }
 }

--- a/src/test/java/org/jboss/ejb/client/test/reconnect/ReconnectTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/reconnect/ReconnectTestCase.java
@@ -22,6 +22,10 @@
 
 package org.jboss.ejb.client.test.reconnect;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 import org.jboss.ejb.client.ContextSelector;
 import org.jboss.ejb.client.EJBClient;
 import org.jboss.ejb.client.EJBClientConfiguration;
@@ -33,10 +37,6 @@ import org.jboss.ejb.client.test.common.DummyServer;
 import org.jboss.logging.Logger;
 import org.junit.Assert;
 import org.junit.Test;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.Properties;
 
 /**
  * Tests various reconnect scenarios for remote connections registered in a EJB client context
@@ -175,6 +175,166 @@ public class ReconnectTestCase {
             final String echo = proxy.echo(message);
             Assert.assertEquals("Got an unexpected echo", echo, message);
 
+        } finally {
+            if (server != null) {
+                try {
+                    server.stop();
+                } catch (Exception e) {
+                    // ignore
+                    logger.debug("Ignoring exception during server shutdown", e);
+                }
+            }
+            if (propertiesStream != null) {
+                propertiesStream.close();
+            }
+            if (oldEJBClientContextSelector != null) {
+                EJBClientContext.setSelector(oldEJBClientContextSelector);
+            }
+        }
+
+    }
+
+    /**
+     * Tests that a re-connection to a server, which went down after it was initially connected,
+     * is successful under concurrent invocation attempts.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testConcurrentReconnectOfBrokenConnection() throws Exception {
+        ContextSelector<EJBClientContext> oldEJBClientContextSelector = null;
+        DummyServer server = null;
+        final String ejbClientConfigResource = "reconnect-jboss-ejb-client.properties";
+        final InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream(ejbClientConfigResource);
+        final int NUM_CONCURRENT_REQUESTS = 10;
+        try {
+            Assert.assertNotNull("Could not find " + ejbClientConfigResource + " through classloader", propertiesStream);
+            // start the server and register the deployment
+            server = this.startServer();
+            server.register("my-app", "my-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+            logger.info("Started server");
+
+            // load the ejb client properties
+            final Properties ejbClientProperties = new Properties();
+            ejbClientProperties.load(propertiesStream);
+
+            // create a configuration out of the properites
+            final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(ejbClientProperties);
+            // create and set the selector
+            oldEJBClientContextSelector = EJBClientContext.setSelector(new ConfigBasedEJBClientContextSelector(ejbClientConfiguration));
+
+            // create a proxy for invocation
+            final StatelessEJBLocator<Echo> statelessEJBLocator = new StatelessEJBLocator<Echo>(Echo.class, "my-app", "my-module", EchoBean.class.getSimpleName(), "");
+            final Echo proxy = EJBClient.createProxy(statelessEJBLocator);
+            Assert.assertNotNull("Received a null proxy", proxy);
+
+            // try invoking
+            final String message = "Yet another Hello World!!!";
+            // should succeed since the server is up
+            final String firstEcho = proxy.echo(message);
+            Assert.assertEquals("Unexpected echo message returned by the bean", firstEcho, message);
+
+            // now stop the server
+            server.stop();
+            server = null;
+            logger.info("Stopped server");
+
+            // now invoke on the proxy and this should fail since the server is down
+            try {
+                final String echo = proxy.echo(message);
+                Assert.fail("Invocation was expected to fail since the server has been stopped");
+            } catch (IllegalStateException ise) {
+                // expected
+                logger.info("Got the expected failure during invocation on proxy, due to server being down", ise);
+            }
+
+            // now restart server and register the deployment
+            server = this.startServer();
+            server.register("my-app", "my-module", "", EchoBean.class.getSimpleName(), new EchoBean());
+            logger.info("Re-started server");
+
+            // now invoke on the proxy. This should succeed since the reconnect logic should now reconnect to the
+            // restarted server
+            Thread[] threads = new Thread[NUM_CONCURRENT_REQUESTS];
+            for (int i = 0; i < NUM_CONCURRENT_REQUESTS; i++) {
+                final int requestId = i + 1;
+                final String requestIdString = requestId + " / " + NUM_CONCURRENT_REQUESTS;
+                threads[i] = new Thread() {
+                    public void run() {
+                        try {
+                            logger.info("Sending invocation: " + requestIdString);
+                            final String echo = proxy.echo(message);
+                            Assert.assertEquals("Got an unexpected echo", echo, message);
+                            logger.info("Got expected invocation result: " + requestIdString);
+                        } catch (Exception e) {
+                            logger.info("Got exception from request " + requestIdString + ": " + e.getMessage());
+                        }
+                    }
+                };
+                threads[i].start();
+            }
+            // wait for the threads to complete
+            for (int i = 0; i < NUM_CONCURRENT_REQUESTS;i++) {
+                threads[i].join();
+            }
+
+        } finally {
+            if (server != null) {
+                try {
+                    server.stop();
+                    logger.info("Stopped server");
+                } catch (Exception e) {
+                    // ignore
+                    logger.debug("Ignoring exception during server shutdown", e);
+                }
+            }
+            if (propertiesStream != null) {
+                propertiesStream.close();
+            }
+            if (oldEJBClientContextSelector != null) {
+                EJBClientContext.setSelector(oldEJBClientContextSelector);
+            }
+        }
+    }
+    /**
+     * Test async reconnection. We try if the asyn reconnection is working even if an ejb is not called (and force the reconnection)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testAsyncReconnectConnection() throws Exception {
+        ContextSelector<EJBClientContext> oldEJBClientContextSelector = null;
+        DummyServer server = null;
+        final String ejbClientConfigResource = "async-reconnect-jboss-ejb-client.properties";
+        final InputStream propertiesStream = this.getClass().getClassLoader().getResourceAsStream(ejbClientConfigResource);
+        try {
+            Assert.assertNotNull("Could not find " + ejbClientConfigResource + " through classloader", propertiesStream);
+            // start the server and register the deployment
+            server = this.startServer();
+
+            // load the ejb client properties
+            final Properties ejbClientProperties = new Properties();
+            ejbClientProperties.load(propertiesStream);
+
+            // create a configuration out of the properites
+            final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(ejbClientProperties);
+            // create and set the selector
+            oldEJBClientContextSelector = EJBClientContext.setSelector(new ConfigBasedEJBClientContextSelector(ejbClientConfiguration));
+
+            // force the reconnect async
+            EJBClientContext ejbClientContext = EJBClientContext.getCurrent();
+
+            // wait for an open channel in the server
+            for(int i = 0; i < 10; i++) {
+                if(server.getNumberChannelsOpened() > 0) {
+                   break;
+                };
+                Thread.sleep(1000L);
+            }
+
+            Assert.assertTrue(server.getNumberChannelsOpened() > 0);
+
+            ejbClientContext.close();
         } finally {
             if (server != null) {
                 try {

--- a/src/test/resources/async-reconnect-jboss-ejb-client.properties
+++ b/src/test/resources/async-reconnect-jboss-ejb-client.properties
@@ -1,0 +1,30 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2012, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+remote.connectionprovider.create.options.org.xnio.Options.SSL_ENABLED=false
+
+remote.connections=one
+
+remote.connection.one.host=localhost
+remote.connection.one.port=6999
+remote.connection.one.protocol=remote
+remote.connection.one.connect.eager=false
+remote.connection.one.connect.options.org.xnio.Options.SASL_POLICY_NOANONYMOUS=false


### PR DESCRIPTION
Jira Upstream. https://issues.jboss.org/browse/EJBCLIENT-94
BZ 6x: https://bugzilla.redhat.com/show_bug.cgi?id=1020074

forward port test from EJBCLIENT-121 (test case in 1.x)
added new test case for async reconnection (no service registered)
task reconnect cleanup during closing ejbclientcontext operation