### PR TITLE
[EJBCLIENT-140] Avoid using stale weak affinity values for node selection.  

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
   ~ 02110-1301 USA, or see the FSF site: http://www.fsf.org.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -39,6 +40,7 @@
 
     <properties>
         <version.checkstyle.plugin>2.9.1</version.checkstyle.plugin>
+        <version.org.jboss.byteman>3.0.1</version.org.jboss.byteman>
         <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
         <version.org.jboss.logging.jboss-logging-processor>1.1.0.Final</version.org.jboss.logging.jboss-logging-processor>
         <version.org.jboss.logmanager>1.5.2.Final</version.org.jboss.logmanager>
@@ -180,6 +182,32 @@
             <artifactId>jboss-transaction-api_1.1_spec</artifactId>
             <version>${version.org.jboss.spec.javax.transaction}</version>
             <scope>provided</scope>
+        </dependency>
+
+        <!-- byteman -->
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-submit</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-install</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.byteman}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.byteman</groupId>
+            <artifactId>byteman-bmunit</artifactId>
+            <scope>test</scope>
+            <version>${version.org.jboss.byteman}</version>
         </dependency>
 
         <!-- JUnit -->

--- a/src/main/java/org/jboss/ejb/client/ReceiverInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/ReceiverInterceptor.java
@@ -70,13 +70,19 @@ public final class ReceiverInterceptor implements EJBClientInterceptor {
                 final Affinity weakAffinity = invocationContext.getInvocationHandler().getWeakAffinity();
                 if (weakAffinity instanceof NodeAffinity) {
                     final String nodeName = ((NodeAffinity) weakAffinity).getNodeName();
-                    final EJBReceiver nodeReceiver;
+                    EJBReceiver nodeReceiver;
                     // ignore the weak affinity if the node has been marked as excluded for this invocation context
                     if (excludedNodes.contains(nodeName)) {
                         logger.debugf("Ignoring weak affinity on node %s since that node has been marked as excluded for invocation context %s", nodeName, invocationContext);
                         nodeReceiver = null;
                     } else {
                         nodeReceiver = clientContext.getNodeEJBReceiver(nodeName);
+                        // ignore the weak affinity if it no longer supports the locator
+                        if (nodeReceiver != null && !nodeReceiver.acceptsModule(locator.getAppName(),locator.getModuleName(),locator.getDistinctName())) {
+                            logger.debugf("Ignoring weak affinity on node %s since that node does not currently accept %s", nodeName, locator);
+                            invocationContext.markNodeAsExcluded(nodeName);
+                            nodeReceiver = null;
+                        }
                     }
                     if (nodeReceiver != null && clientContext.clusterContains(((ClusterAffinity) affinity).getClusterName(), nodeReceiver.getNodeName())) {
                         receiverContext = clientContext.requireEJBReceiverContext(nodeReceiver);
@@ -90,13 +96,19 @@ public final class ReceiverInterceptor implements EJBClientInterceptor {
                 final Affinity weakAffinity = invocationContext.getInvocationHandler().getWeakAffinity();
                 if (weakAffinity instanceof NodeAffinity) {
                     final String nodeName = ((NodeAffinity) weakAffinity).getNodeName();
-                    final EJBReceiver nodeReceiver;
+                    EJBReceiver nodeReceiver;
                     // ignore the weak affinity if the node has been marked as excluded for this invocation context
                     if (excludedNodes.contains(nodeName)) {
                         logger.debugf("Ignoring weak affinity on node %s since that node has been marked as excluded for invocation context %s", nodeName, invocationContext);
                         nodeReceiver = null;
                     } else {
                         nodeReceiver = clientContext.getNodeEJBReceiver(nodeName);
+                        // ignore the weak affinity if it no longer supports the locator
+                        if (nodeReceiver != null && !nodeReceiver.acceptsModule(locator.getAppName(),locator.getModuleName(),locator.getDistinctName())) {
+                            logger.debugf("Ignoring weak affinity on node %s since that node does not currently accept %s", nodeName, locator);
+                            invocationContext.markNodeAsExcluded(nodeName);
+                            nodeReceiver = null;
+                        }
                     }
                     if (nodeReceiver != null) {
                         receiverContext = clientContext.requireEJBReceiverContext(nodeReceiver);
@@ -121,6 +133,7 @@ public final class ReceiverInterceptor implements EJBClientInterceptor {
                 throw new IllegalStateException("Unknown affinity type");
             }
         }
+        logger.debug("Sending invocation to node " + receiverContext.getReceiver().getNodeName());
         invocationContext.setReceiverInvocationContext(new EJBReceiverInvocationContext(invocationContext, receiverContext));
         invocationContext.sendRequest();
     }

--- a/src/test/resources/check-for-retry.btm
+++ b/src/test/resources/check-for-retry.btm
@@ -1,0 +1,24 @@
+RULE check for retry
+CLASS  org.jboss.ejb.client.remoting.NoSuchEJBExceptionResponseHandler
+METHOD processMessage
+AT EXIT
+# get the invocation id which triggered the retry
+BIND id = $invocationId ;
+# any action we perform will be performed here and now - in other words, at exit of this method
+IF true
+  DO debug("retry called for invocation");
+  traceln("id = "+ id);
+  # set a flag to indicate that retry was called
+  flag("retry called")
+ENDRULE
+
+RULE stop test if retry occurs
+CLASS  org.jboss.ejb.client.EJBInvocationHandler
+METHOD invoke
+AT EXIT
+IF flagged("retry called")
+  DO debug("retry was called for invocation - raising exception");
+  # fail the test case now .
+  THROW new RuntimeException("Retry was called");
+ENDRULE
+


### PR DESCRIPTION
This PR introduces additional checking on the client side ReceiverInterceptor to avoid sending invocations to nodes which no longer support clustered SLSB/SFSB locators due to received module unavailable updates. This avoids one unnecessary retry for these invocations and reduces noise in server logs.

For details: see https://issues.jboss.org/browse/EJBCLIENT-140