### PR TITLE
[EJBCLIENT-130] (2.1) Fix to: Cleanup stale waiting invocationID upon retry  of invocation attempt which failed with NoSuchEJBException

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
@@ -75,10 +75,11 @@ class NoSuchEJBExceptionResponseHandler extends ProtocolMessageHandler {
         // retry the invocation on a different node
         try {
             logger.info("Retrying invocation which failed on node " + receiverInvocationContext.getNodeName() + " with exception:", noSuchEJBException);
-            // EJBCLIENT-130: remove any stale invocationID associated with the failed invocation from
-            // the ChannelAssociation map of waiting method invocations
-            this.channelAssociation.cleanupStaleResponse(invocationId);
             receiverInvocationContext.retryInvocation(true);
+
+            // EJBCLIENT-130: remove any stale invocationID associated with the failed invocation from
+            // the ChannelAssociation map of waiting method invocations, if the retry is successful
+            this.channelAssociation.cleanupStaleResponse(invocationId);
         } catch (Exception e) {
             // retry failed, let the waiting client know of this failure
             this.channelAssociation.resultReady(invocationId, new ResultProducer(e));


### PR DESCRIPTION
This is a fix from 2.1 branch which did not make it into 2.x