### PR TITLE
[BZ-976654][EJBCLIENT-82] Add ability to the EJB client configuration to allow a way to specify whether a specific connection needs to be established eagerly or lazily

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientConfiguration.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientConfiguration.java
@@ -22,10 +22,11 @@
 
 package org.jboss.ejb.client;
 
-import org.xnio.OptionMap;
+import java.util.Iterator;
 
 import javax.security.auth.callback.CallbackHandler;
-import java.util.Iterator;
+
+import org.xnio.OptionMap;
 
 /**
  * {@link EJBClientConfiguration} is responsible for providing the configurations that will be used
@@ -162,6 +163,17 @@ public interface EJBClientConfiguration {
          * @return
          */
         OptionMap getChannelCreationOptions();
+
+        /**
+         * If this method returns true, then the EJB client API will try and connect to the destination host "eagerly". when the {@link EJBClientContext}
+         * is being created out of the {@link EJBClientConfiguration} to which this connection configuration belongs.
+         * <p/>
+         * On the other hand, if this method returns false, then the EJB client API will try to connect to the destination host only if no other node/EJBReceiver within the EJB client context
+         * can handle a EJB invocation request. i.e. it tries to establish the connection lazily/on-demand.
+         *
+         * @return
+         */
+        boolean isConnectEagerly();
     }
 
     /**

--- a/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionClusterNodeManager.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/RemotingConnectionClusterNodeManager.java
@@ -22,6 +22,8 @@
 
 package org.jboss.ejb.client.remoting;
 
+import javax.security.auth.callback.CallbackHandler;
+
 import org.jboss.ejb.client.ClusterContext;
 import org.jboss.ejb.client.ClusterNodeManager;
 import org.jboss.ejb.client.DefaultCallbackHandler;
@@ -32,8 +34,6 @@ import org.jboss.logging.Logger;
 import org.jboss.remoting3.Connection;
 import org.jboss.remoting3.Endpoint;
 import org.xnio.OptionMap;
-
-import javax.security.auth.callback.CallbackHandler;
 
 /**
  * A {@link RemotingConnectionClusterNodeManager} uses JBoss Remoting to create a {@link EJBReceiver}
@@ -148,6 +148,12 @@ class RemotingConnectionClusterNodeManager implements ClusterNodeManager {
         @Override
         public OptionMap getChannelCreationOptions() {
             return this.channelCreationOptions;
+        }
+
+        @Override
+        public boolean isConnectEagerly() {
+            // connecting to cluster node is always on-demand and not eager. So return false.
+            return false;
         }
     }
 }

--- a/src/test/java/org/jboss/ejb/client/test/properties/PropertiesBasedEJBClientConfigurationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/test/properties/PropertiesBasedEJBClientConfigurationTestCase.java
@@ -89,6 +89,72 @@ public class PropertiesBasedEJBClientConfigurationTestCase {
 
     }
 
+
+    /**
+     * Tests that the <code>remote.connection.&lt;connection-name&gt;.connect.eager</code> property can be used to control the connection creation behaviour.
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testLazyConnectionConfiguration() throws Exception {
+        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("lazy-connection-jboss-ejb-client.properties");
+        final Properties clientProperties = new Properties();
+        clientProperties.load(inputStream);
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(clientProperties);
+
+        // connection configurations
+        final Iterator<EJBClientConfiguration.RemotingConnectionConfiguration> connectionConfigs = ejbClientConfiguration.getConnectionConfigurations();
+        Assert.assertNotNull("No connection configurations found", connectionConfigs);
+
+        while (connectionConfigs.hasNext()) {
+            final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig = connectionConfigs.next();
+            final String hostName = connectionConfig.getHost();
+            Assert.assertNotNull("Host name was null in connection configuration", hostName);
+            if ("lazy".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy", connectionConfig.isConnectEagerly());
+            } else if ("eager".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager", connectionConfig.isConnectEagerly());
+            } else if ("default".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager (by default)", connectionConfig.isConnectEagerly());
+            }
+        }
+
+    }
+
+    /**
+     * Tests that the properties configuration can be used to specify <code>remote.connections.connect.eager=false</code> as a default to be applied for all listed
+     * connection configurations (unless it's overridden for a specific connection configuration)
+     *
+     * @throws Exception
+     */
+    @Test
+    public void testDefaultLazyConnectionConfiguration() throws Exception {
+        final InputStream inputStream = this.getClass().getClassLoader().getResourceAsStream("default-lazy-connections-jboss-ejb-client.properties");
+        final Properties clientProperties = new Properties();
+        clientProperties.load(inputStream);
+
+        final EJBClientConfiguration ejbClientConfiguration = new PropertiesBasedEJBClientConfiguration(clientProperties);
+
+        // connection configurations
+        final Iterator<EJBClientConfiguration.RemotingConnectionConfiguration> connectionConfigs = ejbClientConfiguration.getConnectionConfigurations();
+        Assert.assertNotNull("No connection configurations found", connectionConfigs);
+
+        while (connectionConfigs.hasNext()) {
+            final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig = connectionConfigs.next();
+            final String hostName = connectionConfig.getHost();
+            Assert.assertNotNull("Host name was null in connection configuration", hostName);
+            if ("lazy".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy", connectionConfig.isConnectEagerly());
+            } else if ("eager".equals(hostName)) {
+                Assert.assertTrue("Connection configuration was expected to be marked as eager", connectionConfig.isConnectEagerly());
+            } else if ("default".equals(hostName)) {
+                Assert.assertFalse("Connection configuration was expected to be marked as lazy (by default)", connectionConfig.isConnectEagerly());
+            }
+        }
+
+    }
+
     private void testConnectionConfigOne(final EJBClientConfiguration.RemotingConnectionConfiguration connectionConfig) {
         // port
         final int port = connectionConfig.getPort();

--- a/src/test/resources/default-lazy-connections-jboss-ejb-client.properties
+++ b/src/test/resources/default-lazy-connections-jboss-ejb-client.properties
@@ -1,0 +1,38 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+
+endpoint.name=test-endpoint-name
+
+remote.connections=a,b,c
+remote.connections.connect.eager=false
+
+remote.connection.a.host=default
+remote.connection.a.port=6999
+
+remote.connection.b.host=eager
+remote.connection.b.port=4999
+remote.connection.b.connect.eager=true
+
+remote.connection.c.host=lazy
+remote.connection.c.port=4999
+remote.connection.c.connect.eager=false
+

--- a/src/test/resources/lazy-connection-jboss-ejb-client.properties
+++ b/src/test/resources/lazy-connection-jboss-ejb-client.properties
@@ -1,0 +1,35 @@
+#
+# JBoss, Home of Professional Open Source.
+# Copyright 2013, Red Hat, Inc., and individual contributors
+# as indicated by the @author tags. See the copyright.txt file in the
+# distribution for a full listing of individual contributors.
+#
+# This is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Lesser General Public License as
+# published by the Free Software Foundation; either version 2.1 of
+# the License, or (at your option) any later version.
+#
+# This software is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this software; if not, write to the Free
+# Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+# 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+#
+endpoint.name=test-endpoint-name
+
+remote.connections=lazy,default,eager
+
+remote.connection.lazy.host=lazy
+remote.connection.lazy.port=6999
+remote.connection.lazy.connect.eager=false
+
+remote.connection.eager.host=eager
+remote.connection.eager.port=4999
+remote.connection.eager.connect.eager=true
+
+remote.connection.default.host=default
+remote.connection.default.port=8999


### PR DESCRIPTION
6.4.x BZ: https://bugzilla.redhat.com/show_bug.cgi?id=976654
JIRA (already merged): https://issues.jboss.org/browse/EJBCLIENT-82

EJBCLIENT-82 backport to 1.0.x branch
https://github.com/jbossas/jboss-ejb-client/pull/50

