### PR TITLE
[BZ-1266112] ConcurrentModificationException in ClusterContext.getConnectedAndDeployedNodes

### DIFF
--- a/src/main/java/org/jboss/ejb/client/ClusterContext.java
+++ b/src/main/java/org/jboss/ejb/client/ClusterContext.java
@@ -267,7 +267,7 @@ public final class ClusterContext implements EJBClientContext.EJBReceiverContext
 
     public Set<String> getConnectedAndDeployedNodes(EJBLocator locator) {
         Set<String> connectedAndDeployed = Collections.synchronizedSet(new HashSet<String>());
-        synchronized (this) {
+        synchronized (this.connectedNodes) {
             for (String node : this.connectedNodes) {
                 if (isNodeConnectedAndDeployed(node, locator)) {
                     connectedAndDeployed.add(node);


### PR DESCRIPTION
BZ  6.4.x : https://bugzilla.redhat.com/show_bug.cgi?id=1266112
forward port : #130 
correcting the sync block to right lock object to avoid the exception.
All the actions performed over the sync set should be sync with sync set
instance.