### PR TITLE
Use context classloader to load the ejb component view class - fix

### DIFF
--- a/src/main/java/org/jboss/ejb/client/naming/EJBRootContext.java
+++ b/src/main/java/org/jboss/ejb/client/naming/EJBRootContext.java
@@ -143,7 +143,7 @@ class EJBRootContext extends AbstractContext {
         if (sm != null) {
             classLoader = AccessController.doPrivileged((PrivilegedAction<ClassLoader>) EJBRootContext::doGetContextClassLoader);
         } else {
-            classLoader = getContextClassLoader();
+            classLoader = doGetContextClassLoader();
         }
         return classLoader;
     }


### PR DESCRIPTION
I made a mistake in my previous PR having make a wrong invocation in non security manager scenario.