### PR TITLE
[BZ-1299844] Deadlock in EJB client

### DIFF
--- a/src/main/java/org/jboss/ejb/client/ClusterContext.java
+++ b/src/main/java/org/jboss/ejb/client/ClusterContext.java
@@ -28,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -266,12 +267,15 @@ public final class ClusterContext implements EJBClientContext.EJBReceiverContext
     }
 
     public Set<String> getConnectedAndDeployedNodes(EJBLocator locator) {
-        Set<String> connectedAndDeployed = Collections.synchronizedSet(new HashSet<String>());
+        Set<String> connectedAndDeployed = new HashSet<String>();
         synchronized (this.connectedNodes) {
-            for (String node : this.connectedNodes) {
-                if (isNodeConnectedAndDeployed(node, locator)) {
-                    connectedAndDeployed.add(node);
-                }
+            connectedAndDeployed.addAll(this.connectedNodes);
+        }
+        Iterator<String> iteratorConnectedNodes = connectedAndDeployed.iterator();
+        while(iteratorConnectedNodes.hasNext()) {
+            String node = iteratorConnectedNodes.next();
+            if (!isNodeConnectedAndDeployed(node, locator)) {
+                iteratorConnectedNodes.remove();
             }
         }
         return connectedAndDeployed;


### PR DESCRIPTION
Jira : https://issues.jboss.org/browse/EJBCLIENT-152
6.4.z: https://bugzilla.redhat.com/show_bug.cgi?id=1299844

this reduce the scope of the lock during the calculation of available nodes.
this avoids the deadlock during the invocation of an EJB and the cluster
connectivity lost.