### PR TITLE
[BZ-1302181, EJBCLIENT-153] Too many invocations to a remote EJB from…

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/ChannelAssociation.java
@@ -167,7 +167,16 @@ class ChannelAssociation {
      * @return
      */
     short getNextInvocationId() {
-        return (short) nextInvocationId.getAndIncrement();
+        for (;;) {
+            short nextId = (short) nextInvocationId.getAndIncrement();
+            if (this.waitingMethodInvocations.containsKey(nextId)) {
+                continue;
+            }
+            if (this.waitingFutureResults.containsKey(nextId)) {
+                continue;
+            }
+            return nextId;
+        }
     }
 
     /**

--- a/src/test/java/org/jboss/ejb/client/remoting/ChannelAssociationTestCase.java
+++ b/src/test/java/org/jboss/ejb/client/remoting/ChannelAssociationTestCase.java
@@ -1,0 +1,106 @@
+package org.jboss.ejb.client.remoting;
+
+import java.io.IOException;
+
+import org.jboss.remoting3.Attachments;
+import org.jboss.remoting3.Channel;
+import org.jboss.remoting3.CloseHandler;
+import org.jboss.remoting3.Connection;
+import org.jboss.remoting3.MessageOutputStream;
+import org.junit.Assert;
+import org.junit.Test;
+import org.xnio.Option;
+
+/**
+ * @author Tomas Hofman (thofman@redhat.com)
+ */
+public class ChannelAssociationTestCase {
+
+    private ChannelAssociation channelAssociation = new ChannelAssociation(null, null, new ChannelStub(), (byte) 1, null, null);
+
+    @Test
+    public void testGetInvocationIdSkipAsync() {
+        // checks that invocation IDs that are already registered are skipped when generating next ID
+        Assert.assertEquals(0, channelAssociation.getNextInvocationId());
+        channelAssociation.enrollForResult((short) 1);
+        channelAssociation.enrollForResult((short) 2);
+        Assert.assertEquals(3, channelAssociation.getNextInvocationId());
+    }
+
+    @Test
+    public void testGetInvocationIdSkipSync() {
+        // checks that invocation IDs that are already registered are skipped when generating next ID
+        Assert.assertEquals(0, channelAssociation.getNextInvocationId());
+        channelAssociation.receiveResponse((short) 1, null);
+        channelAssociation.receiveResponse((short) 2, null);
+        Assert.assertEquals(3, channelAssociation.getNextInvocationId());
+    }
+
+    private static class ChannelStub implements Channel {
+
+        @Override
+        public Connection getConnection() {
+            return null;
+        }
+
+        @Override
+        public MessageOutputStream writeMessage() throws IOException {
+            return null;
+        }
+
+        @Override
+        public void writeShutdown() throws IOException {
+
+        }
+
+        @Override
+        public void receiveMessage(Receiver handler) {
+
+        }
+
+        @Override
+        public boolean supportsOption(Option<?> option) {
+            return false;
+        }
+
+        @Override
+        public <T> T getOption(Option<T> option) {
+            return null;
+        }
+
+        @Override
+        public <T> T setOption(Option<T> option, T value) throws IllegalArgumentException {
+            return null;
+        }
+
+        @Override
+        public void close() throws IOException {
+
+        }
+
+        @Override
+        public void awaitClosed() throws InterruptedException {
+
+        }
+
+        @Override
+        public void awaitClosedUninterruptibly() {
+
+        }
+
+        @Override
+        public void closeAsync() {
+
+        }
+
+        @Override
+        public Key addCloseHandler(CloseHandler<? super Channel> handler) {
+            return null;
+        }
+
+        @Override
+        public Attachments getAttachments() {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
… multiple threads cause infinite wait

https://bugzilla.redhat.com/show_bug.cgi?id=1302181
Upstream PR: https://github.com/jbossas/jboss-ejb-client/pull/135 (not yet merged)