### PR TITLE
[EJBCLIENT-137] Disable retry from managed transaction context.

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/NoSuchEJBExceptionResponseHandler.java
@@ -22,6 +22,8 @@
 
 package org.jboss.ejb.client.remoting;
 
+import org.jboss.ejb.client.AttachmentKeys;
+import org.jboss.ejb.client.EJBClientInvocationContext;
 import org.jboss.ejb.client.EJBReceiverInvocationContext;
 import org.jboss.logging.Logger;
 
@@ -65,10 +67,19 @@ class NoSuchEJBExceptionResponseHandler extends ProtocolMessageHandler {
         } finally {
             dataInputStream.close();
         }
+        // get the receiver invocation context
         final EJBReceiverInvocationContext receiverInvocationContext = this.channelAssociation.getEJBReceiverInvocationContext(invocationId);
         if (receiverInvocationContext == null) {
             logger.info("Cannot retry invocation which failed with exception:", noSuchEJBException);
             // let the client know the result, since we can't retry without a receiver invocation context
+            this.channelAssociation.resultReady(invocationId, new ResultProducer(noSuchEJBException));
+            return;
+        }
+        // if the invocation is associated with a transaction, disable retry
+        EJBClientInvocationContext clientInvocationContext = receiverInvocationContext.getClientInvocationContext();
+        if (clientInvocationContext.getAttachment(AttachmentKeys.TRANSACTION_ID_KEY) != null) {
+            logger.info("Cannot retry transaction-scoped invocation which failed with exception:", noSuchEJBException);
+            // let the client know the result, since we can't retry with a transaction context
             this.channelAssociation.resultReady(invocationId, new ResultProducer(noSuchEJBException));
             return;
         }


### PR DESCRIPTION
This PR:
- disables retry in the case that the EJBClientInvocationContext has a transaction associated with it when retry is attempted
- causes a NoSuchEJBException to be returned to the client when an invocation is made from a managed transaction context and the node associated with the transaction is not available, even if the deployment to which the invocation is made is clustered
