### PR TITLE
[EJBCLIENT-170] Do not propagate transactions for async methods unless forced to

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBProxyInformation.java
+++ b/src/main/java/org/jboss/ejb/client/EJBProxyInformation.java
@@ -99,8 +99,9 @@ final class EJBProxyInformation<T> {
                     // seems a likely match
                     try {
                         final Method method = (Method) declaredField.get(null);
+                        final boolean alwaysAsync = method.getReturnType() == Future.class;
                         final boolean idempotent = classIdempotent || method.getAnnotation(Idempotent.class) != null;
-                        final boolean clientAsync = classAsync || method.getAnnotation(ClientAsynchronous.class) != null;
+                        final boolean clientAsync = alwaysAsync || classAsync || method.getAnnotation(ClientAsynchronous.class) != null;
                         final CompressionHint compressionHint = method.getAnnotation(CompressionHint.class);
                         final ClientTransaction transactionHint = method.getAnnotation(ClientTransaction.class);
                         final int compressionLevel;
@@ -116,7 +117,7 @@ final class EJBProxyInformation<T> {
                             compressRequest = compressionHint.compressRequest();
                             compressResponse = compressionHint.compressResponse();
                         }
-                        transactionPolicy = transactionHint != null ? transactionHint.value() : classTransactionHint != null ? classTransactionHint.value() : null;
+                        transactionPolicy = transactionHint != null ? transactionHint.value() : clientAsync ? ClientTransactionPolicy.NOT_SUPPORTED : classTransactionHint != null ? classTransactionHint.value() : ClientTransactionPolicy.SUPPORTS;
                         // build the old signature format
                         final StringBuilder b = new StringBuilder();
                         final Class<?>[] methodParamTypes = method.getParameterTypes();

--- a/src/main/java/org/jboss/ejb/client/TransactionInterceptor.java
+++ b/src/main/java/org/jboss/ejb/client/TransactionInterceptor.java
@@ -28,7 +28,6 @@ import java.security.PrivilegedAction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.transaction.RollbackException;
 import javax.transaction.SystemException;
 import javax.transaction.Transaction;
 import javax.transaction.TransactionManager;
@@ -58,11 +57,7 @@ public final class TransactionInterceptor implements EJBClientInterceptor {
     }
 
     public void handleInvocation(final EJBClientInvocationContext context) throws Exception {
-        ClientTransactionPolicy transactionPolicy = context.getTransactionPolicy();
-        if (transactionPolicy == null) {
-            // TODO: per-thread and/or global default settings
-            transactionPolicy = ClientTransactionPolicy.SUPPORTS;
-        }
+        final ClientTransactionPolicy transactionPolicy = context.getTransactionPolicy();
         final TransactionManager transactionManager = transactionManagerSupplier.get();
         final Transaction transaction = safeGetTransaction(transactionManager);
 


### PR DESCRIPTION
The policy is:
- If there is a ClientTransaction annotation on the method, use the specified mode, otherwise:
- If the method is asynchronous (returns Future or is tagged with the ClientAsynchronous annotation), use NOT_SUPPORTED, otherwise:
- If the method's enclosing class has a ClientTransaction annotation, use the specified mode, otherwise:
- Use the default mode (SUPPORTS).
