### PR TITLE
Add fix for WF testsuite intermittent failures that was present in EJB Client 2.1.4.Final

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientContext.java
@@ -62,6 +62,8 @@ import org.jboss.remoting3.Connection;
 @SuppressWarnings({"UnnecessaryThis"})
 public final class EJBClientContext extends Attachable implements Closeable {
 
+    private static final boolean WILDFLY_TESTSUITE_HACK = Boolean.getBoolean("org.jboss.ejb.client.wildfly-testsuite-hack");
+
     private static final Logger logger = Logger.getLogger(EJBClientContext.class);
 
     private static final RuntimePermission SET_SELECTOR_PERMISSION = new RuntimePermission("setEJBClientContextSelector");
@@ -698,8 +700,19 @@ public final class EJBClientContext extends Attachable implements Closeable {
             throws IllegalStateException {
 
         // try and find a receiver which can handle this combination
-        final EJBReceiver ejbReceiver = this.getEJBReceiver(appName, moduleName, distinctName);
+        EJBReceiver ejbReceiver = this.getEJBReceiver(appName, moduleName, distinctName);
         if (ejbReceiver == null) {
+            if(WILDFLY_TESTSUITE_HACK) {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                ejbReceiver = this.getEJBReceiver(appName, moduleName, distinctName);
+                if (ejbReceiver != null) {
+                    return ejbReceiver;
+                }
+            }
             throw Logs.MAIN.noEJBReceiverAvailableForDeployment(appName, moduleName, distinctName);
         }
         return ejbReceiver;
@@ -769,8 +782,19 @@ public final class EJBClientContext extends Attachable implements Closeable {
             throws IllegalStateException {
 
         // try and find a receiver which can handle this combination
-        final EJBReceiver ejbReceiver = this.getEJBReceiver(clientInvocationContext, appName, moduleName, distinctName);
+        EJBReceiver ejbReceiver = this.getEJBReceiver(clientInvocationContext, appName, moduleName, distinctName);
         if (ejbReceiver == null) {
+            if(WILDFLY_TESTSUITE_HACK) {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                ejbReceiver = this.getEJBReceiver(clientInvocationContext, appName, moduleName, distinctName);
+                if (ejbReceiver != null) {
+                    return ejbReceiver;
+                }
+            }
             throw Logs.MAIN.noEJBReceiverAvailableForDeploymentDuringInvocation(appName, moduleName, distinctName, clientInvocationContext);
         }
         return ejbReceiver;
@@ -833,8 +857,19 @@ public final class EJBClientContext extends Attachable implements Closeable {
             throws IllegalStateException {
 
         // try and find a receiver which can handle this combination
-        final EJBReceiver ejbReceiver = this.getEJBReceiver(excludedNodeNames, appName, moduleName, distinctName);
+        EJBReceiver ejbReceiver = this.getEJBReceiver(excludedNodeNames, appName, moduleName, distinctName);
         if (ejbReceiver == null) {
+            if(WILDFLY_TESTSUITE_HACK) {
+                try {
+                    Thread.sleep(2000);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+                ejbReceiver = this.getEJBReceiver(excludedNodeNames, appName, moduleName, distinctName);
+                if (ejbReceiver != null) {
+                    return ejbReceiver;
+                }
+            }
             throw Logs.MAIN.noEJBReceiverAvailableForDeployment(appName, moduleName, distinctName);
         }
         return ejbReceiver;


### PR DESCRIPTION
Just discovered that this commit from Stuart was present in EJB Client 2.1.4.Final, the version used in WildFly before we switched to the temp EJB client. The temp EJB Client branch was based off the 2.x jboss-ejb-client branch. However, the 2.x branch was missing this particular commit. Based off Stuart's description of this commit in [WFLY-4973](https://issues.jboss.org/browse/WFLY-4973), it seems like this should resolve the intermittent failures we've been seeing this week in the WildFly test suite.