### PR TITLE
EJBRootContext: parse the last property during lookup

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBRootContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBRootContext.java
@@ -116,6 +116,11 @@ class EJBRootContext extends AbstractContext {
                     eq = -1;
                 }
             }
+            if ("stateful".equals(lastPart.substring(st, eq == -1 ? lastPart.length() : eq))) {
+                if (eq == -1 || "true".equalsIgnoreCase(lastPart.substring(eq + 1))) {
+                    stateful = true;
+                }
+            }
         }
         Class<?> view;
         try {


### PR DESCRIPTION
The last property from the name is not parsed - so for example single "?stateful" at the end is not recognized.