### PR TITLE
[EJBCLIENT-176] Avoid interceptor chain index inconsistencies caused by concurrent invocation of retry mechanisms

### DIFF
--- a/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
+++ b/src/main/java/org/jboss/ejb/client/EJBClientInvocationContext.java
@@ -509,6 +509,28 @@ public final class EJBClientInvocationContext extends Attachable {
         }
     }
 
+    boolean isDone() {
+        assert !holdsLock(lock);
+        synchronized (lock) {
+            switch (state) {
+                case WAITING: {
+                    return false;
+                }
+                case CANCEL_REQ:
+                case READY:
+                case FAILED:
+                case CANCELLED:
+                case DONE:
+                case CONSUMING:
+                case DISCARDED: {
+                    return true;
+                }
+                default:
+                    throw new IllegalStateException();
+            }
+        }
+    }
+
     final class FutureResponse implements Future<Object> {
 
         public boolean cancel(final boolean mayInterruptIfRunning) {

--- a/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/EJBInvocationHandler.java
@@ -269,6 +269,13 @@ final class EJBInvocationHandler<T> extends Attachable implements InvocationHand
                     throw (UnmarshalException) rsfe.getCause();
                 }
             }
+            // check to see if the request has already been retried by response-triggered retry mechanism
+            // despite the fact that the send raised an exception (see WFLY-6417)
+            if (clientInvocationContext.isDone()) {
+                Logs.MAIN.debugf(rsfe, "Aborting client-side retry of invocation %s (the request has already returned), due to:", clientInvocationContext);
+                return;
+            }
+            // retry the request
             final String failedNodeName = rsfe.getFailedNodeName();
             if (failedNodeName != null) {
                 Logs.MAIN.debugf(rsfe, "Retrying invocation %s which failed on node: %s due to:", clientInvocationContext, failedNodeName);


### PR DESCRIPTION
This PR fixes an issue with multiple EJB client retry mechanisms (invocation send retry mecuanism and invocation receipt retry mechanism)  getting invoked at the same time.