### PR TITLE
Add slow fallback map for odd class loading cases, and associated fixes

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
@@ -23,14 +23,17 @@
 package org.jboss.ejb.protocol.remote;
 
 import static java.lang.Math.min;
+import static java.security.AccessController.doPrivileged;
 import static org.xnio.IoUtils.safeClose;
 
 import java.io.DataInput;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.lang.reflect.Proxy;
 import java.net.Inet6Address;
 import java.net.SocketAddress;
+import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -426,7 +429,7 @@ final class EJBServerChannel {
                         parameterTypeNames[j ++] = sigString.substring(i);
                     }
                 }
-                methodLocator = EJBMethodLocator.create(methodName, parameterTypeNames);
+                methodLocator = new EJBMethodLocator(methodName, parameterTypeNames);
                 identity = connection.getLocalIdentity();
             }
             final RemotingInvocationRequest request = new RemotingInvocationRequest(
@@ -947,6 +950,24 @@ final class EJBServerChannel {
 
         ServerClassResolver() {
             super(true);
+        }
+
+        public Class<?> resolveProxyClass(final Unmarshaller unmarshaller, final String[] interfaces) throws IOException, ClassNotFoundException {
+            final int length = interfaces.length;
+            final Class<?>[] classes = new Class<?>[length];
+
+            for(int i = 0; i < length; ++i) {
+                classes[i] = this.loadClass(interfaces[i]);
+            }
+
+            final ClassLoader classLoader;
+            if (length == 1) {
+                classLoader = doPrivileged((PrivilegedAction<ClassLoader>) classes[0]::getClassLoader);
+            } else {
+                classLoader = getClassLoader();
+            }
+
+            return Proxy.getProxyClass(classLoader, classes);
         }
 
         protected ClassLoader getClassLoader() {

--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
@@ -377,7 +377,7 @@ final class EJBServerChannel {
             final EJBIdentifier identifier = new EJBIdentifier(appName, moduleName, beanName, distName);
 
             connection.getLocalIdentity(securityContext).runAs((Runnable) () ->
-                association.receiveSessionOpenRequest(new RemotingSessionOpenRequest<Object>(
+                association.receiveSessionOpenRequest(new RemotingSessionOpenRequest(
                     invId,
                     identifier,
                     transactionSupplier
@@ -612,7 +612,7 @@ final class EJBServerChannel {
         }
     }
 
-    final class RemotingSessionOpenRequest<T> extends RemotingRequest implements SessionOpenRequest {
+    final class RemotingSessionOpenRequest extends RemotingRequest implements SessionOpenRequest {
         private final EJBIdentifier identifier;
         final ExceptionSupplier<ImportResult<?>, SystemException> transactionSupplier;
         int txnCmd = 0; // assume nobody will ask about the transaction


### PR DESCRIPTION
…to avoid mismatch on deserialize and other possible scenarios involving creation of a proxy under differing class loaders than expected