### PR TITLE
[EJBCLIENT-196] Fix the way we differentiate between an IPv6 and IPv4 address when processing CLUSTER_TOPOLOGY_ADDITION and CLUSTER_TOPOLOGY_COMPLETE messages

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBClientChannel.java
@@ -25,6 +25,7 @@ package org.jboss.ejb.protocol.remote;
 import static java.lang.Math.min;
 import static java.security.AccessController.doPrivileged;
 import static org.wildfly.common.math.HashMath.multiHashOrdered;
+import static org.xnio.Bits.allAreClear;
 import static org.xnio.Bits.allAreSet;
 import static org.xnio.IoUtils.safeClose;
 
@@ -359,7 +360,7 @@ class EJBClientChannel {
                             int mappingCount = StreamUtils.readPackedSignedInt32(message);
                             for (int k = 0; k < mappingCount; k ++) {
                                 int b = message.readUnsignedByte();
-                                final boolean ip6 = allAreSet(b, 1);
+                                final boolean ip6 = allAreClear(b, 1);
                                 int netmaskBits = b >>> 1;
                                 final byte[] sourceIpBytes = new byte[ip6 ? 16 : 4];
                                 message.readFully(sourceIpBytes);


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-196