### PR TITLE
Also replace the affinity of deserialized locators if it is NONE

### DIFF
--- a/src/main/java/org/jboss/ejb/client/SerializedEJBInvocationHandler.java
+++ b/src/main/java/org/jboss/ejb/client/SerializedEJBInvocationHandler.java
@@ -132,7 +132,7 @@ public final class SerializedEJBInvocationHandler implements Externalizable {
     private static <T> EJBInvocationHandler<T> readResolve(EJBLocator<T> locator) {
         NamingProvider namingProvider = NamingProvider.getCurrentNamingProvider();
         if (namingProvider != null) {
-            if (locator.getAffinity() == Affinity.LOCAL) {
+            if (locator.getAffinity() == Affinity.LOCAL || locator.getAffinity() == Affinity.NONE) {
                 return new EJBInvocationHandler<T>(namingProvider, locator.withNewAffinity(Affinity.forUri(namingProvider.getProviderUri())));
             } else {
                 return new EJBInvocationHandler<T>(namingProvider, locator);

--- a/src/main/java/org/jboss/ejb/protocol/remote/ProtocolV3ObjectResolver.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/ProtocolV3ObjectResolver.java
@@ -36,7 +36,7 @@ final class ProtocolV3ObjectResolver implements ObjectResolver {
 
     public Object readResolve(final Object replacement) {
         // Swap a local affinity with a URI affinity with the peer's URI
-        if (replacement == Affinity.LOCAL) {
+        if (replacement == Affinity.LOCAL || replacement == Affinity.NONE) {
             return peerURIAffinity;
         }
         return replacement;


### PR DESCRIPTION
This occurs with legacy servers, which have no affinity