### PR TITLE
Add support for the proceed async message

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/EJBServerChannel.java
@@ -875,6 +875,21 @@ final class EJBServerChannel {
             }
         }
 
+        @Override
+        public void writeProceedAsync() {
+            if(version >= 3) {
+                //not used in newer protocols
+                return;
+            }
+            try (MessageOutputStream os = messageTracker.openMessageUninterruptibly()) {
+                os.writeByte(Protocol.PROCEED_ASYNC_RESPONSE);
+                os.writeShort(invId);
+            } catch (IOException e) {
+                // nothing to do at this point; the client doesn't want the response
+                Logs.REMOTING.trace("EJB async response write failed", e);
+            }
+        }
+
         @NotNull
         public EJBIdentifier getEJBIdentifier() {
             return identifier;

--- a/src/main/java/org/jboss/ejb/server/InvocationRequest.java
+++ b/src/main/java/org/jboss/ejb/server/InvocationRequest.java
@@ -66,6 +66,13 @@ public interface InvocationRequest extends Request {
      */
     void writeSessionNotActive();
 
+
+    /**
+     * Write a message indicating that this is an async request. If this is not required by the underlying protocol then
+     * this may be a noop
+     */
+    default void writeProceedAsync() {};
+
     /**
      * The resolved content of the request.
      */


### PR DESCRIPTION
This is needed for legacy clients to solve https://issues.jboss.org/browse/JBEAP-9669

I am not sure if it should be send for all protocol versions, or only for versions 1 and 2