### PR TITLE
EJBCLIENT-212 Response compression does not work for protocol v2

### DIFF
--- a/protocol.txt
+++ b/protocol.txt
@@ -100,7 +100,7 @@ Version is 0x01 or 0x02 or 0x03. 0x00 is reserved for test purposes.
         ┌─┬─┬─┬─┬─┬─┬─┬─┐
         │ 0x1B          │  Compressed request (optional, if present everything following is compressed)
         ├───────────────┤
-        │ 0x03          │  Command = Invocation Request or Compressed Invocation Request
+        │ 0x03          │  Command = Invocation Request
         ├───────────────┤
         │ Invocation ID │  Fixed length, two bytes
         ├───────────────┤


### PR DESCRIPTION
Note that this adds a performance penalty that could be solved by changing the API to pass the Method object into writeResponse. The penalty will affect all invocations that use v2 of the protocol.