### PR TITLE
[EJBCLIENT-225] Some more fixes to JBossEJBProperties in anticipation of EJBCLIENT-225

### DIFF
--- a/src/main/java/org/jboss/ejb/client/legacy/JBossEJBProperties.java
+++ b/src/main/java/org/jboss/ejb/client/legacy/JBossEJBProperties.java
@@ -632,7 +632,7 @@ public final class JBossEJBProperties implements Contextual<JBossEJBProperties> 
                     }
                 }
 
-                setChannelOptions(getOptionMapFromProperties(properties, prefix + ".channel.options.", classLoader));
+                setChannelOptions(getOptionMapFromProperties(properties, prefix + "channel.options" + ".", classLoader));
 
                 final ExceptionSupplier<CallbackHandler, ReflectiveOperationException> callbackHandlerSupplier =
                     () -> Class.forName(callbackHandlerClassName, true, classLoader).asSubclass(CallbackHandler.class).getConstructor().newInstance();
@@ -803,7 +803,7 @@ public final class JBossEJBProperties implements Contextual<JBossEJBProperties> 
                     return false;
                 }
                 setClusterName(clusterName);
-                setMaximumAllowedConnectedNodes(getLongValueFromProperties(properties, prefix + "max-connected-nodes", 1000L));
+                setMaximumAllowedConnectedNodes(getLongValueFromProperties(properties, prefix + "max-allowed-connected-nodes", 1000L));
                 final String clusterNodeSelectorClassName = getProperty(properties, prefix + "clusternode.selector", null, true);
                 if (clusterNodeSelectorClassName != null) {
                     setClusterNodeSelectorClassName(clusterNodeSelectorClassName);


### PR DESCRIPTION
Found an error in the original commit: the maximum number of connected nodes for a cluster is referred to as max-allowed-connected-nodes in PropertiesBasedEJBClientConfiguration and not max-connected-nodes as committed. That mistake is rectified here.

Also, found another"extra dot" issue with reading connect.options, and that is fixed here as well.
