### PR TITLE
[EJBCLIENT-225] Reinstate ignored test cases post EJBCLIENT-216.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>2.11</version>
                 <configuration>
+                    <forkMode>always</forkMode>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <systemProperties>
                         <property>


### PR DESCRIPTION
The PR un-ignores the two cluster-based test cases which will pass now that EJBCLIENT-216 is merged.