### PR TITLE
EJBCLIENT-237 MethodInvocationResponseHandler not putting response contextData on InvocationContext

### DIFF
--- a/src/main/java/org/jboss/ejb/client/remoting/MethodInvocationResponseHandler.java
+++ b/src/main/java/org/jboss/ejb/client/remoting/MethodInvocationResponseHandler.java
@@ -105,6 +105,10 @@ class MethodInvocationResponseHandler extends ProtocolMessageHandler {
                 // read the attachments
                 final Map<String, Object> attachments = MethodInvocationResponseHandler.this.readAttachments(unmarshaller);
 
+                if(this.clientInvocationContext != null && attachments != null) {
+                    this.clientInvocationContext.getContextData().putAll(attachments);
+                }
+
                 // finish unmarshalling
                 unmarshaller.finish();
                 // see if there's a weak affinity passed as an attachment. If yes, then attach it to the client invocation


### PR DESCRIPTION
https://issues.jboss.org/browse/EJBCLIENT-237

upstream: https://issues.jboss.org/browse/EJBCLIENT-203
upstream PR: https://github.com/jbossas/jboss-ejb-client/pull/242 (already merged)