### PR TITLE
[EJBCLIENT-545] Allow an explicit Endpoint to be passed instead of creating new one.

### DIFF
--- a/src/main/java/org/jboss/ejb/protocol/remote/RemoteEJBReceiver.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemoteEJBReceiver.java
@@ -65,15 +65,21 @@ class RemoteEJBReceiver extends EJBReceiver {
     private final RemoteTransportProvider remoteTransportProvider;
     private final EJBReceiverContext receiverContext;
     private final RemotingEJBDiscoveryProvider discoveredNodeRegistry;
+    private final Endpoint endpoint;
 
     final ClientServiceHandle<EJBClientChannel> serviceHandle;
 
     private final RetryExecutorWrapper retryExecutorWrapper = new RetryExecutorWrapper();
 
     RemoteEJBReceiver(final RemoteTransportProvider remoteTransportProvider, final EJBReceiverContext receiverContext, final RemotingEJBDiscoveryProvider discoveredNodeRegistry) {
+        this(remoteTransportProvider, receiverContext, discoveredNodeRegistry, Endpoint.getCurrent());
+    }
+
+    RemoteEJBReceiver(final RemoteTransportProvider remoteTransportProvider, final EJBReceiverContext receiverContext, final RemotingEJBDiscoveryProvider discoveredNodeRegistry, final Endpoint endpoint) {
         this.remoteTransportProvider = remoteTransportProvider;
         this.receiverContext = receiverContext;
         this.discoveredNodeRegistry = discoveredNodeRegistry;
+        this.endpoint = endpoint;
         serviceHandle = new ClientServiceHandle<>("jboss.ejb", channel -> EJBClientChannel.construct(channel, this.discoveredNodeRegistry, retryExecutorWrapper));
     }
 
@@ -117,7 +123,7 @@ class RemoteEJBReceiver extends EJBReceiver {
             } else if (exception instanceof SSLException && exception.getMessage().equals("Unrecognized SSL message, plaintext connection?")) {
                 Logs.REMOTING.error("Error in connecting to " + destination + " : The destination doesn't support SSL. Did you mean to use http protocol instead?");
             }
-            attachment.requestFailed(new RequestSendFailedException("Error in connecting to Destination @" + destination + " : Please check if the client and server are configured to use the same protocol and ports. ", exception, false), retryExecutorWrapper.getExecutor(Endpoint.getCurrent().getXnioWorker()));
+            attachment.requestFailed(new RequestSendFailedException("Error in connecting to Destination @" + destination + " : Please check if the client and server are configured to use the same protocol and ports. ", exception, false), retryExecutorWrapper.getExecutor(endpoint.getXnioWorker()));
         }
     };
 
@@ -180,11 +186,11 @@ class RemoteEJBReceiver extends EJBReceiver {
     }
 
     protected InetSocketAddress getSourceAddress(final InetSocketAddress destination) {
-        return Endpoint.getCurrent().getXnioWorker().getBindAddress(destination.getAddress());
+        return endpoint.getXnioWorker().getBindAddress(destination.getAddress());
     }
 
     protected boolean isConnected(final URI uri) {
-        final IoFuture<ConnectionPeerIdentity> future = Endpoint.getCurrent().getConnectedIdentityIfExists(uri, "ejb", "jboss", AuthenticationContext.captureCurrent());
+        final IoFuture<ConnectionPeerIdentity> future = endpoint.getConnectedIdentityIfExists(uri, "ejb", "jboss", AuthenticationContext.captureCurrent());
         try {
             return future != null && future.getStatus() == IoFuture.Status.DONE && future.get().getConnection().isOpen();
         } catch (IOException e) {
@@ -199,17 +205,17 @@ class RemoteEJBReceiver extends EJBReceiver {
 
         if (cluster != null) {
             if(System.getSecurityManager() == null) {
-                return discoveredNodeRegistry.getConnectedIdentityUsingClusterEffective(Endpoint.getCurrent(), target, "ejb", "jboss", authenticationContext, cluster);
+                return discoveredNodeRegistry.getConnectedIdentityUsingClusterEffective(endpoint, target, "ejb", "jboss", authenticationContext, cluster);
             } else {
                 return doPrivileged((PrivilegedAction<IoFuture<ConnectionPeerIdentity>>) () ->
-                        discoveredNodeRegistry.getConnectedIdentityUsingClusterEffective(Endpoint.getCurrent(), target, "ejb", "jboss", authenticationContext, cluster));
+                        discoveredNodeRegistry.getConnectedIdentityUsingClusterEffective(endpoint, target, "ejb", "jboss", authenticationContext, cluster));
             }
         }
 
         if(System.getSecurityManager() == null) {
-            return Endpoint.getCurrent().getConnectedIdentity(target, "ejb", "jboss", authenticationContext);
+            return endpoint.getConnectedIdentity(target, "ejb", "jboss", authenticationContext);
         } else {
-            return doPrivileged((PrivilegedAction<IoFuture<ConnectionPeerIdentity>>) () -> Endpoint.getCurrent().getConnectedIdentity(target, "ejb", "jboss", authenticationContext));
+            return doPrivileged((PrivilegedAction<IoFuture<ConnectionPeerIdentity>>) () -> endpoint.getConnectedIdentity(target, "ejb", "jboss", authenticationContext));
         }
     }
 

--- a/src/main/java/org/jboss/ejb/protocol/remote/RemoteTransportProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemoteTransportProvider.java
@@ -24,7 +24,9 @@ import org.jboss.ejb.client.EJBClientContext;
 import org.jboss.ejb.client.EJBReceiver;
 import org.jboss.ejb.client.EJBReceiverContext;
 import org.jboss.ejb.client.EJBTransportProvider;
+import org.jboss.remoting3.Endpoint;
 import org.kohsuke.MetaInfServices;
+import org.wildfly.common.Assert;
 
 /**
  * The JBoss Remoting-based transport provider.
@@ -37,12 +39,20 @@ public final class RemoteTransportProvider implements EJBTransportProvider {
     static final AttachmentKey<RemoteEJBReceiver> ATTACHMENT_KEY = new AttachmentKey<>();
     private static final Logs log = Logs.MAIN;
 
+    private final Endpoint endpoint;
+
     public RemoteTransportProvider() {
+        this(Endpoint.getCurrent());
+    }
+
+    public RemoteTransportProvider(final Endpoint endpoint) {
+        Assert.checkNotNullParam("endpoint", endpoint);
+        this.endpoint = endpoint;
     }
 
     public void notifyRegistered(final EJBReceiverContext receiverContext) {
         final EJBClientContext clientContext = receiverContext.getClientContext();
-        RemoteEJBReceiver receiver = new RemoteEJBReceiver(this, receiverContext, new RemotingEJBDiscoveryProvider());
+        RemoteEJBReceiver receiver = new RemoteEJBReceiver(this, receiverContext, new RemotingEJBDiscoveryProvider(endpoint), endpoint);
         clientContext.putAttachmentIfAbsent(ATTACHMENT_KEY, receiver);
         log.tracef("RemoteTransportProvider %s registered receiver %s with client context %s", this, receiver, clientContext);
     }

--- a/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
+++ b/src/main/java/org/jboss/ejb/protocol/remote/RemotingEJBDiscoveryProvider.java
@@ -93,8 +93,14 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
     
     private static final long DESTINATION_RECHECK_INTERVAL = TimeUnit.MILLISECONDS.toNanos(SecurityUtils.getLong(SystemProperties.DESTINATION_RECHECK_INTERVAL, 5000L));
 
+    private final Endpoint endpoint;
+
     public RemotingEJBDiscoveryProvider() {
-        Endpoint.getCurrent(); //this will blow up if remoting is not present, preventing this from being registered
+        this(Endpoint.getCurrent()); //this will blow up if remoting is not present, preventing this from being registered
+    }
+
+    public RemotingEJBDiscoveryProvider(Endpoint endpoint) {
+        this.endpoint = endpoint;
     }
 
     public NodeInformation getNodeInformation(final String nodeName) {
@@ -149,7 +155,7 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
 
         final List<EJBClientConnection> configuredConnections = ejbClientContext.getConfiguredConnections();
 
-        final DiscoveryAttempt discoveryAttempt = new DiscoveryAttempt(serviceType, filterSpec, result, ejbReceiver, AuthenticationContext.captureCurrent());
+        final DiscoveryAttempt discoveryAttempt = new DiscoveryAttempt(serviceType, filterSpec, result, ejbReceiver, AuthenticationContext.captureCurrent(), endpoint);
 
         boolean ok = false;
         boolean discoveryConnections = false;
@@ -369,14 +375,14 @@ final class RemotingEJBDiscoveryProvider implements DiscoveryProvider, Discovere
          */
         private final Set<String> eagerNodes;
 
-        DiscoveryAttempt(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult discoveryResult, final RemoteEJBReceiver ejbReceiver, final AuthenticationContext authenticationContext) {
+        DiscoveryAttempt(final ServiceType serviceType, final FilterSpec filterSpec, final DiscoveryResult discoveryResult, final RemoteEJBReceiver ejbReceiver, final AuthenticationContext authenticationContext, final Endpoint endpoint) {
             this.serviceType = serviceType;
             this.filterSpec = filterSpec;
             this.discoveryResult = discoveryResult;
             this.ejbReceiver = ejbReceiver;
 
             this.authenticationContext = authenticationContext;
-            endpoint = Endpoint.getCurrent();
+            this.endpoint = endpoint;
             outerNotifier = new IoFuture.HandlingNotifier<ConnectionPeerIdentity, URI>() {
                 public void handleCancelled(final URI destination) {
                     countDown();


### PR DESCRIPTION
Issue: https://redhat.atlassian.net/browse/EJBCLIENT-545
Currently the component does not allow to pass a preconfigured endpoint. In the case of a wildfly
subsystem the server configures already the endpoint for remoting